### PR TITLE
JCS-13072 : Create network VCN Terraform module using new Terraform version.

### DIFF
--- a/modules/network/vcn/outputs.tf
+++ b/modules/network/vcn/outputs.tf
@@ -1,3 +1,6 @@
+# Copyright (c) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at https://oss.oracle.com/licenses/upl.
+
 # Output of the vcn creation
 output "vcn_id" {
   description = "The OCID of the new VCN"

--- a/modules/network/vcn/variables.tf
+++ b/modules/network/vcn/variables.tf
@@ -1,3 +1,6 @@
+# Copyright (c) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at https://oss.oracle.com/licenses/upl.
+
 variable "compartment_id" {
   type        = string
   description = "The OCID of the compartment where the VCN will be created"
@@ -23,12 +26,6 @@ variable "wls_vcn_cidr" {
   type        = string
   description = "The IPv4 CIDR block that will be assigned for the VCN"
   default     = ""
-}
-
-variable "use_existing_subnets" {
-  type        = bool
-  description = "Set to true if the existing subnets are used to create VCN"
-  default     = false
 }
 
 variable "tags" {

--- a/modules/network/vcn/vcn.tf
+++ b/modules/network/vcn/vcn.tf
@@ -1,3 +1,6 @@
+# Copyright (c) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at https://oss.oracle.com/licenses/upl.
+
 resource "oci_core_virtual_network" "wls_vcn" {
 
   cidr_block     = var.wls_vcn_cidr


### PR DESCRIPTION
Fix for [JCS-13072](https://jira.oraclecorp.com/jira/browse/JCS-13072) : Create network VCN Terraform module using new Terraform version

Tested creating new vcn.

