### PR TITLE
Fix issue when provisioning without dynamic group tags

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -11,12 +11,13 @@ locals {
   wls_availability_domain     = var.use_regional_subnet ? (var.wls_availability_domain_name == "" ? local.ad_names[0] : var.wls_availability_domain_name) : (var.wls_subnet_id == "" ? var.wls_availability_domain_name : data.oci_core_subnet.wls_subnet[0].availability_domain)
   network_compartment_id      = var.network_compartment_id == "" ? var.compartment_id : var.network_compartment_id
 
-  dg_system_tags_key = format("%s.%s", module.system-tags.tag_namespace, module.system-tags.dg_tag_key)
+  #dynamic group is based on the system generated tags for DG
+  create_dg_tags     = var.create_policies && var.generate_dg_tag # Only create dynamic group tags when create policies and generate dg tag is true
+  dg_system_tags_key = local.create_dg_tags ? format("%s.%s", module.system-tags.tag_namespace, module.system-tags.dg_tag_key) : ""
   dynamic_group_rule = local.create_dg_tags ? format("%s.%s.%s='%s'", "tag", local.dg_system_tags_key, "value", module.system-tags.dg_tag_value) : length(var.service_tags.definedTags) > 0 ? format("tag.%s.value='%s'", keys(var.service_tags.definedTags)[0], values(var.service_tags.definedTags)[0]) : ""
-  dg_defined_tags    = zipmap([local.dg_system_tags_key], [module.system-tags.dg_tag_value])
+  dg_defined_tags    = local.create_dg_tags ? zipmap([local.dg_system_tags_key], [module.system-tags.dg_tag_value]) : {}
   defined_tags       = var.service_tags.definedTags
   free_form_tags     = length(var.service_tags.freeformTags) > 0 ? var.service_tags.freeformTags : module.system-tags.system_tag_value
-  create_dg_tags     = var.create_policies && var.generate_dg_tag
 
   # Locals used by outputs
   bastion_public_ip = element(coalescelist(module.bastion[*].public_ip, data.oci_core_instance.existing_bastion_instance.*.public_ip, [""]), 0)


### PR DESCRIPTION
- Add checks for local.create_dg_tags when defining some variables used
to generate dynamic group tags
- Fixes issue when provisioning with generate_dg_tag = false, because
compute had an invalid defined tag in that case

The tags added to the compute were like these:
 + defined_tags                        = {
          + "."                               = "test3-5bfd79bb"
          + "test-tag-namespace.test-tag-key" = "value5"
        }
The first one caused an error:

Error: 400-Bad Request, Tag key or namespace cannot be null or zero length string literal
│ Suggestion: Please retry or contact support for help with service: Core Instance
│ Documentation: https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_instance
│ API Reference: https://docs.oracle.com/iaas/api/#/en/iaas/20160918/Instance/LaunchInstance
│ Request Target: POST https://iaas.us-phoenix-1.oraclecloud.com/20160918/instances
│ Provider version: 4.83.0, released on 2022-07-05. This provider is 6 Update(s) behind to current.
│ Service: Core Instance
│ Operation Name: LaunchInstance
│ OPC request ID:---
│
│
│   with module.compute.module.wls-instances.oci_core_instance.these["test3-wls-0"],
│   on modules\compute\instance\instance.tf line 4, in resource "oci_core_instance" "these":
│    4: resource "oci_core_instance" "these" {
