### PR TITLE
Remove code to create lb2 subnet and its NSGs

### DIFF
--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -94,7 +94,6 @@ locals {
   bastion_subnet_cidr       = var.bastion_subnet_cidr == "" && var.wls_vcn_name != "" && !local.assign_weblogic_public_ip ? local.is_vcn_peering ? "11.0.1.0/24" : "10.0.1.0/24" : var.bastion_subnet_cidr
   wls_subnet_cidr           = var.wls_subnet_cidr == "" && var.wls_vcn_name != "" ? local.is_vcn_peering ? "11.0.2.0/24" : "10.0.2.0/24" : var.wls_subnet_cidr
   lb_subnet_1_subnet_cidr   = var.lb_subnet_1_cidr == "" && var.wls_vcn_name != "" ? local.is_vcn_peering ? "11.0.3.0/24" : "10.0.3.0/24" : var.lb_subnet_1_cidr
-  lb_subnet_2_subnet_cidr   = var.lb_subnet_2_cidr == "" && var.wls_vcn_name != "" ? local.is_vcn_peering ? "11.0.4.0/24" : "10.0.4.0/24" : var.lb_subnet_2_cidr
   mount_target_subnet_cidr  = var.mount_target_subnet_cidr == "" && var.wls_vcn_name != "" ? local.is_vcn_peering ? "11.0.5.0/24" : "10.0.5.0/24" : var.mount_target_subnet_cidr
 
   num_ads = length(

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -41,7 +41,7 @@ module "network-vcn-config" {
 
   wls_security_list_name       = !var.assign_weblogic_public_ip ? "bastion-security-list" : "wls-security-list"
   wls_subnet_cidr              = local.wls_subnet_cidr
-  wls_ms_source_cidrs          = var.add_load_balancer ? ((local.use_regional_subnet || local.is_single_ad_region) ? [local.lb_subnet_1_subnet_cidr] : [local.lb_subnet_1_subnet_cidr, local.lb_subnet_2_subnet_cidr]) : ["0.0.0.0/0"]
+  wls_ms_source_cidrs          = var.add_load_balancer ? [local.lb_subnet_1_subnet_cidr] : ["0.0.0.0/0"]
   load_balancer_min_value      = var.add_load_balancer ? var.wls_ms_extern_port : var.wls_ms_extern_ssl_port
   load_balancer_max_value      = var.add_load_balancer ? var.wls_ms_extern_port : var.wls_ms_extern_ssl_port
   create_load_balancer         = var.add_load_balancer
@@ -156,27 +156,6 @@ module "network-lb-subnet-1" {
     defined_tags  = local.defined_tags
     freeform_tags = local.free_form_tags
   }
-}
-
-/* Create secondary subnet for wls and lb backend */
-module "network-lb-subnet-2" {
-  source          = "./modules/network/subnet"
-  count           = local.add_existing_load_balancer ? 0 : var.add_load_balancer && local.lb_subnet_2_id == "" && !var.is_lb_private && !local.use_regional_subnet && !local.is_single_ad_region ? 1 : 0
-  compartment_id  = local.network_compartment_id
-  vcn_id          = local.vcn_id
-  dhcp_options_id = module.network-vcn-config[0].dhcp_options_id
-  route_table_id  = module.network-vcn-config[0].route_table_id
-  subnet_name     = "${local.service_name_prefix}-${local.lb_subnet_2_name}"
-  #Note: limit for dns label is 15 chars
-  dns_label          = format("%s-%s", local.lb_subnet_2_name, substr(strrev(var.service_name), 0, 7))
-  cidr_block         = local.lb_subnet_2_subnet_cidr
-  prohibit_public_ip = var.is_lb_private
-
-  tags = {
-    defined_tags  = local.defined_tags
-    freeform_tags = local.free_form_tags
-  }
-
 }
 
 /* Create back end subnet for bastion subnet */
@@ -352,7 +331,6 @@ module "validators" {
   existing_vcn_id              = var.wls_existing_vcn_id
   wls_subnet_cidr              = var.wls_subnet_cidr
   lb_subnet_1_cidr             = var.lb_subnet_1_cidr
-  lb_subnet_2_cidr             = var.lb_subnet_2_cidr
   bastion_subnet_cidr          = var.bastion_subnet_cidr
   assign_public_ip             = local.assign_weblogic_public_ip
   is_bastion_instance_required = var.is_bastion_instance_required
@@ -431,7 +409,7 @@ module "load-balancer" {
   lb_min_bandwidth         = var.lb_min_bandwidth
   lb_name                  = "${local.service_name_prefix}-lb"
   lb_subnet_1_id           = var.lb_subnet_1_id != "" ? [var.lb_subnet_1_id] : [module.network-lb-subnet-1[0].subnet_id]
-  lb_subnet_2_id           = var.lb_subnet_2_id != "" ? [var.lb_subnet_2_id] : element(concat([module.network-lb-subnet-2[*].subnet_id], [""]), 0)
+  lb_subnet_2_id           = [var.lb_subnet_2_id]
 
   tags = {
     defined_tags  = local.defined_tags

--- a/terraform/modules/validators/network_validators.tf
+++ b/terraform/modules/validators/network_validators.tf
@@ -8,7 +8,6 @@ locals {
   has_mgmt_subnet_cidr = var.is_bastion_instance_required ? (var.bastion_subnet_cidr != "" || var.existing_bastion_instance_id != "") : true
 
   has_lb_subnet_1_cidr     = var.lb_subnet_1_cidr != ""
-  has_lb_subnet_2_cidr     = var.lb_subnet_2_cidr != ""
   missing_wls_subnet_cidr  = var.existing_vcn_id != "" && var.wls_subnet_id == "" ? !local.has_wls_subnet_cidr : false
   add_new_load_balancer    = var.add_load_balancer && var.existing_load_balancer_id == ""
   missing_lb_subnet_1_cidr = local.add_new_load_balancer && var.existing_vcn_id != "" && var.lb_subnet_1_id == "" ? !local.has_lb_subnet_1_cidr : false
@@ -17,20 +16,13 @@ locals {
   missing_mgmt_backend_subnet_cidr   = (var.existing_vcn_id != "" && !var.assign_public_ip && var.bastion_subnet_id == "" && var.is_bastion_instance_required && var.existing_bastion_instance_id == "") ? !local.has_mgmt_subnet_cidr : false
 
   duplicate_wls_subnet_cidr_with_lb1_cidr            = (local.add_new_load_balancer) && (local.has_lb_subnet_1_cidr) && (local.has_wls_subnet_cidr) && (var.wls_subnet_cidr == var.lb_subnet_1_cidr)
-  duplicate_wls_subnet_cidr_with_lb2_cidr            = (local.add_new_load_balancer) && (var.use_regional_subnet == false) && (local.has_lb_subnet_2_cidr) && (local.has_wls_subnet_cidr) && (var.wls_subnet_cidr == var.lb_subnet_2_cidr)
   duplicate_wls_subnet_cidr_with_private_subnet_cidr = ((var.existing_vcn_id == "") && (!var.assign_public_ip) && var.bastion_subnet_id == "") && (local.has_mgmt_subnet_cidr) && (local.has_wls_subnet_cidr) && (var.wls_subnet_cidr == var.bastion_subnet_cidr)
 
-  check_duplicate_wls_subnet_cidr = var.wls_subnet_cidr != "" && (local.duplicate_wls_subnet_cidr_with_lb1_cidr || local.duplicate_wls_subnet_cidr_with_lb2_cidr || local.duplicate_wls_subnet_cidr_with_private_subnet_cidr)
+  check_duplicate_wls_subnet_cidr = var.wls_subnet_cidr != "" && (local.duplicate_wls_subnet_cidr_with_lb1_cidr || local.duplicate_wls_subnet_cidr_with_private_subnet_cidr)
 
   #lb1 check
-  duplicate_lb1_subnet_cidr_with_lb2_cidr            = (local.add_new_load_balancer) && (var.use_regional_subnet == false) && (local.has_lb_subnet_1_cidr) && (local.has_lb_subnet_2_cidr) && (var.lb_subnet_1_cidr == var.lb_subnet_2_cidr)
   duplicate_lb1_subnet_cidr_with_private_subnet_cidr = ((!var.assign_public_ip) && var.bastion_subnet_id == "") && (local.has_mgmt_subnet_cidr) && (local.has_lb_subnet_1_cidr) && (var.lb_subnet_1_cidr == var.bastion_subnet_cidr)
-
-  check_duplicate_lb1_subnet_cidr = local.has_lb_subnet_1_cidr && (local.duplicate_lb1_subnet_cidr_with_lb2_cidr || local.duplicate_lb1_subnet_cidr_with_private_subnet_cidr)
-
-  #lb2 check
-  duplicate_lb2_subnet_cidr_with_private_subnet_cidr = (local.add_new_load_balancer) && (var.use_regional_subnet == false) && ((!var.assign_public_ip) && var.bastion_subnet_id == "") && (local.has_mgmt_subnet_cidr) && (local.has_lb_subnet_2_cidr) && (var.lb_subnet_2_cidr == var.bastion_subnet_cidr)
-  check_duplicate_lb2_subnet_cidr                    = local.has_lb_subnet_2_cidr && local.duplicate_lb2_subnet_cidr_with_private_subnet_cidr
+  check_duplicate_lb1_subnet_cidr                    = local.has_lb_subnet_1_cidr && local.duplicate_lb1_subnet_cidr_with_private_subnet_cidr
 
   missing_vcn               = var.existing_vcn_id == "" && var.vcn_name == ""
   has_existing_vcn          = var.existing_vcn_id != ""
@@ -55,7 +47,7 @@ locals {
 
   #existing private AD subnet
   has_all_existing_private_subnets = (local.add_new_load_balancer && local.has_wls_subnet_id && local.has_lb_frontend_subnet_id && local.has_mgmt_subnet_id) || ((!local.add_new_load_balancer && local.has_wls_subnet_id && local.has_mgmt_subnet_id))
-  has_all_new_private_subnets      = (local.add_new_load_balancer && local.has_wls_subnet_cidr && local.has_lb_subnet_1_cidr && local.has_lb_subnet_2_cidr && local.has_mgmt_subnet_cidr) || (!local.add_new_load_balancer && local.has_wls_subnet_cidr && local.has_mgmt_subnet_cidr)
+  has_all_new_private_subnets      = (local.add_new_load_balancer && local.has_wls_subnet_cidr && local.has_lb_subnet_1_cidr && local.has_mgmt_subnet_cidr) || (!local.add_new_load_balancer && local.has_wls_subnet_cidr && local.has_mgmt_subnet_cidr)
   is_private_subnet_condition      = (local.has_all_existing_private_subnets || local.has_all_new_private_subnets)
   missing_existing_private_subnets = !local.is_private_subnet_condition
 
@@ -108,11 +100,8 @@ locals {
   wls_subnet_cidr_msg       = "WLSC-ERROR:  WebLogic subnet CIDR has to be unique value."
   duplicate_wls_subnet_cidr = local.check_duplicate_wls_subnet_cidr == true ? local.validators_msg_map[local.wls_subnet_cidr_msg] : null
 
-  duplicate_lb1_subnet_cidr_msg = "WLSC-ERROR:  Load balancer subnet 1 CIDR has to be unique value. "
+  duplicate_lb1_subnet_cidr_msg = "WLSC-ERROR:  Load balancer subnet 1 CIDR has to be unique value."
   duplicate_lb1_subnet_cidr     = local.check_duplicate_lb1_subnet_cidr ? local.validators_msg_map[local.duplicate_lb1_subnet_cidr_msg] : null
-
-  duplicate_lb2_subnet_cidr_msg = "WLSC-ERROR:  Load balancer subnet 2 CIDR has to be unique value. "
-  duplicate_lb2_subnet_cidr     = local.check_duplicate_lb2_subnet_cidr ? local.validators_msg_map[local.duplicate_lb2_subnet_cidr_msg] : null
 
   lb_type_msg      = "WLSC-ERROR: Private load balancer can only be provisioned if private subnets are used for provisioning."
   validate_lb_type = local.invalid_lb_type ? local.validators_msg_map[local.lb_type_msg] : null

--- a/terraform/modules/validators/variables.tf
+++ b/terraform/modules/validators/variables.tf
@@ -61,11 +61,6 @@ variable "lb_subnet_1_cidr" {
   description = "CIDR for loadbalancer subnet"
 }
 
-variable "lb_subnet_2_cidr" {
-  type        = string
-  description = "CIDR for loadbalancer subnet"
-}
-
 variable "existing_vcn_id" {
   type        = string
   description = "The OCID of the existing VCN where the WebLogic servers and other resources will be created. If not specified, a new VCN is created"

--- a/terraform/network_variables.tf
+++ b/terraform/network_variables.tf
@@ -152,12 +152,6 @@ variable "lb_subnet_1_cidr" {
   default     = ""
 }
 
-variable "lb_subnet_2_cidr" {
-  type        = string
-  description = "CIDR for loadbalancer subnet"
-  default     = ""
-}
-
 variable "wls_subnet_cidr" {
   type        = string
   description = "CIDR for weblogic subnet"


### PR DESCRIPTION
Tested the following scenarios:
1. Create an instance with new VCN. Show that all subnets, including Lb1 subnet, are regional(Private LB)
2. Create an instance with new VCN. Show that all subnets, including Lb1 subnet, are regional(Public LB)
3. Create an instance with existing VCN and new subnets. Show that all subnets, including Lb1 subnet, are regional
4. Create instance with existing subnets, using AD-specific subnets (Public LB)
