### PR TITLE
Minor fix in data_sources.tf

### DIFF
--- a/terraform/data_sources.tf
+++ b/terraform/data_sources.tf
@@ -71,7 +71,7 @@ data "oci_core_service_gateways" "service_gateways" {
 }
 
 data "oci_core_internet_gateways" "internet_gateways" {
-  compartment_id = var.network_compartment_id
+  compartment_id = local.network_compartment_id
   vcn_id         = local.vcn_id
 }
 


### PR DESCRIPTION
Fix for below error;

Error: marshaling request to a header requires not nil pointer for field: CompartmentId
│ 
│   with data.oci_core_internet_gateways.internet_gateways,
│   on data_sources.tf line 73, in data "oci_core_internet_gateways" "internet_gateways":
│   73: data "oci_core_internet_gateways" "internet_gateways" {
