### PR TITLE
JCS-11824 Enable bastion plugin on WLS OCI VMs

### DIFF
--- a/terraform/db_variables.tf
+++ b/terraform/db_variables.tf
@@ -155,6 +155,7 @@ variable "atp_db_existing_vcn_id" {
 variable "atp_db_uses_private_endpoint" {
   type        = bool
   description = "Indicates if the ATP database uses private endpoint for network access"
+  default     = false
 }
 
 #This variable is used for both oci db and ATP with private subnet

--- a/terraform/modules/compute/instance/instance.tf
+++ b/terraform/modules/compute/instance/instance.tf
@@ -35,6 +35,17 @@ resource "oci_core_instance" "these" {
     source_id   = each.value.source_id
   }
 
+  agent_config {
+    are_all_plugins_disabled = false
+    is_management_disabled   = false
+    is_monitoring_disabled   = false
+    plugins_config {
+      #Required
+      desired_state = "ENABLED"
+      name          = "Bastion"
+    }
+  }
+
   metadata = each.value.metadata
 
   instance_options {


### PR DESCRIPTION
- Add agent_config block to compute module to enable bastion plugin
- Add default value to variable atp_db_uses_private_endpoint