### PR TITLE
JCS-13432: LB availability domain for subnet 1 and 2 shown when creating stack with existing VCN and new subnets

### DIFF
--- a/terraform/network_variables.tf
+++ b/terraform/network_variables.tf
@@ -101,20 +101,6 @@ variable "load_balancer_strategy_existing_subnet" {
   default     = "Create New Load Balancer"
 }
 
-# Variable used in UI only
-variable "lb_subnet_1_availability_domain_name" {
-  type        = string
-  description = "Availability domain for load balancer when using AD-specific subnets"
-  default     = ""
-}
-
-# Variable used in UI only
-variable "lb_subnet_2_availability_domain_name" {
-  type        = string
-  description = "Availability domain for load balancer when using AD-specific subnets"
-  default     = ""
-}
-
 variable "existing_load_balancer_id" {
   type        = string
   description = "The OCID of an existing load balancer. If set, use the existing load balancer and add the stack nodes to the backend set of the existing load balancer. Set add_load_balancer to true in order for this value to take effect"

--- a/terraform/schema.yaml
+++ b/terraform/schema.yaml
@@ -108,9 +108,7 @@ groupings:
       - ${lb_reserved_public_ip_id}
       - ${lb_subnet_1_id}
       - ${lb_subnet_2_id}
-      - ${lb_subnet_1_availability_domain_name}
       - ${lb_subnet_1_cidr}
-      - ${lb_subnet_2_availability_domain_name}
       - ${lb_min_bandwidth}
       - ${lb_max_bandwidth}
       - ${existing_load_balancer_id}
@@ -1235,68 +1233,6 @@ variables:
     required: true
     description: The OCID of the reserved public IP address for the load balancer
     pattern: ^ocid1.publicip.*$
-
-  # check if these fields are any more relevant as we do not create AD subnets
-  lb_subnet_1_availability_domain_name:
-    visible:
-      and:
-        - or:
-            - ${add_load_balancer}
-            - ${is_idcs_selected}
-        - and:
-            - ${create_new_subnets}
-            - eq:
-                - ${subnet_span}
-                - "AD Specific Subnet"
-    type: oci:identity:availabilitydomain:name
-    dependsOn:
-      compartmentId: ${network_compartment_id}
-      hidePrivateSubnet: true
-      hidePublicSubnet: false
-      hideRegionalSubnet:
-        not:
-          - eq:
-              - ${subnet_span}
-              - "Regional Subnet"
-      hideAdSubnet:
-        not:
-          - eq:
-              - ${subnet_span}
-              - "AD Specific Subnet"
-    title: LB Availability Domain for subnet 1
-    description: The availability domain to use for the second load balancer node. This field is required only if you are using AD-specific subnets.
-    default: ''
-
-  # check if these fields are any more relevant as we do not create AD subnets
-  lb_subnet_2_availability_domain_name:
-    visible:
-      and:
-        - or:
-            - ${add_load_balancer}
-            - ${is_idcs_selected}
-        - and:
-            - ${create_new_subnets}
-            - eq:
-                - ${subnet_span}
-                - "AD Specific Subnet"
-    type: oci:identity:availabilitydomain:name
-    dependsOn:
-      compartmentId: ${network_compartment_id}
-      hidePrivateSubnet: true
-      hidePublicSubnet: false
-      hideRegionalSubnet:
-        not:
-          - eq:
-              - ${subnet_span}
-              - "Regional Subnet"
-      hideAdSubnet:
-        not:
-          - eq:
-              - ${subnet_span}
-              - "AD Specific Subnet"
-    title: LB Availability Domain for subnet 2
-    description: Select LB Availability Domain. Only required if provisioning with Load Balancer is selected.
-    default: ''
 
   lb_subnet_1_cidr:
     visible:

--- a/terraform/schema_14110.yaml
+++ b/terraform/schema_14110.yaml
@@ -81,9 +81,7 @@ groupings:
       - ${lb_reserved_public_ip_id}
       - ${lb_subnet_1_id}
       - ${lb_subnet_2_id}
-      - ${lb_subnet_1_availability_domain_name}
       - ${lb_subnet_1_cidr}
-      - ${lb_subnet_2_availability_domain_name}
       - ${lb_min_bandwidth}
       - ${lb_max_bandwidth}
       - ${existing_load_balancer_id}
@@ -1244,68 +1242,6 @@ variables:
     required: true
     description: The OCID of the reserved public IP address for the load balancer
     pattern: ^ocid1.publicip.*$
-
-  # check if these fields are any more relevant as we do not create AD subnets
-  lb_subnet_1_availability_domain_name:
-    visible:
-      and:
-        - or:
-            - ${add_load_balancer}
-            - ${is_idcs_selected}
-        - and:
-            - ${create_new_subnets}
-            - eq:
-                - ${subnet_span}
-                - "AD Specific Subnet"
-    type: oci:identity:availabilitydomain:name
-    dependsOn:
-      compartmentId: ${network_compartment_id}
-      hidePrivateSubnet: true
-      hidePublicSubnet: false
-      hideRegionalSubnet:
-        not:
-          - eq:
-              - ${subnet_span}
-              - "Regional Subnet"
-      hideAdSubnet:
-        not:
-          - eq:
-              - ${subnet_span}
-              - "AD Specific Subnet"
-    title: LB Availability Domain for subnet 1
-    description: The availability domain to use for the second load balancer node. This field is required only if you are using AD-specific subnets.
-    default: ''
-
-  # check if these fields are any more relevant as we do not create AD subnets
-  lb_subnet_2_availability_domain_name:
-    visible:
-      and:
-        - or:
-            - ${add_load_balancer}
-            - ${is_idcs_selected}
-        - and:
-            - ${create_new_subnets}
-            - eq:
-                - ${subnet_span}
-                - "AD Specific Subnet"
-    type: oci:identity:availabilitydomain:name
-    dependsOn:
-      compartmentId: ${network_compartment_id}
-      hidePrivateSubnet: true
-      hidePublicSubnet: false
-      hideRegionalSubnet:
-        not:
-          - eq:
-              - ${subnet_span}
-              - "Regional Subnet"
-      hideAdSubnet:
-        not:
-          - eq:
-              - ${subnet_span}
-              - "AD Specific Subnet"
-    title: LB Availability Domain for subnet 2
-    description: Select LB Availability Domain. Only required if provisioning with Load Balancer is selected.
-    default: ''
 
   lb_subnet_1_cidr:
     visible:


### PR DESCRIPTION
JCS-13432: LB availability domain for subnet 1 and 2 shown when creating stack with existing VCN and new subnets

Tested in UI that subnet availability 1 and 2 don't show up with existing network and new subnets.