### PR TITLE
JCS-13459 MP bundles are asking for defined tags if OCI policies is disabled

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -410,8 +410,8 @@ module "validators" {
   min_threshold_counter = var.min_threshold_counter
   min_threshold_percent = var.min_threshold_percent
 
-  create_dg_tags = local.create_dg_tags
-  service_tags   = var.service_tags
+  generate_dg_tag = var.generate_dg_tag
+  service_tags    = var.service_tags
   tags = {
     defined_tags  = local.defined_tags
     freeform_tags = local.free_form_tags
@@ -557,7 +557,7 @@ module "compute" {
   num_vm_instances              = var.wls_node_count
   resource_name_prefix          = var.service_name
 
-  is_bastion_instance_required       = var.is_bastion_instance_required
+  is_bastion_instance_required = var.is_bastion_instance_required
 
   is_idcs_selected      = var.is_idcs_selected
   idcs_host             = var.idcs_host

--- a/terraform/modules/validators/tag_validators.tf
+++ b/terraform/modules/validators/tag_validators.tf
@@ -32,7 +32,7 @@ locals {
   size_check_defined_tags_msg = "WLSC-ERROR: The defined tag's value should not exceed 256 characters"
   validate_defined_tag_size   = length(local.size_check_defined_tags) != 0 ? local.validators_msg_map[local.size_check_defined_tags_msg] : null
 
-  set_dev_defined_tag          = !var.create_dg_tags && length(var.service_tags.definedTags) == 0
+  set_dev_defined_tag          = var.create_policies && !var.generate_dg_tag && length(var.service_tags.definedTags) == 0
   set_dev_defined_tag_msg      = "WLSC-ERROR: At least one defined tag is required if generate_dg_tag is false or mode is DEV."
   validate_set_dev_defined_tag = local.set_dev_defined_tag ? local.validators_msg_map[local.set_dev_defined_tag_msg] : null
 

--- a/terraform/modules/validators/variables.tf
+++ b/terraform/modules/validators/variables.tf
@@ -446,9 +446,9 @@ variable "num_vm_instances" {
   description = "Number of WebLogic managed servers. One VM per managed server will be created"
 }
 
-variable "create_dg_tags" {
+variable "generate_dg_tag" {
   type        = bool
-  description = "Flag to create defined tags for dynamic group definition"
+  description = "Set to true to generate defined tags for dynamic group definition."
 }
 
 variable "service_tags" {


### PR DESCRIPTION

Fix for JCS-13459 MP bundles are asking for defined tags if OCI policies is disabled

Tested dev and mp bundles with OCI policies set to false and oci policies set to true without providing dev tags .