### PR TITLE
JCS-13479 Policies fail to be created because of removed var

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -195,19 +195,21 @@ module "policies" {
     defined_tags  = local.defined_tags
     freeform_tags = local.free_form_tags
   }
-  atp_db                    = local.atp_db
-  oci_db                    = local.oci_db
-  vcn_id                    = element(concat(module.network-vcn[*].vcn_id, [""]), 0)
-  wls_existing_vcn_id       = var.wls_existing_vcn_id
-  is_idcs_selected          = var.is_idcs_selected
-  idcs_client_secret_id     = var.idcs_client_secret_id
-  use_oci_logging           = var.use_oci_logging
-  use_apm_service           = var.use_apm_service
-  apm_domain_compartment_id = local.apm_domain_compartment_id
-  use_autoscaling           = var.use_autoscaling
-  ocir_auth_token_id        = var.ocir_auth_token_id
-  add_fss                   = var.add_fss
-  add_load_balancer         = var.add_load_balancer
+  atp_db                      = local.atp_db
+  oci_db                      = local.oci_db
+  vcn_id                      = element(concat(module.network-vcn[*].vcn_id, [""]), 0)
+  wls_existing_vcn_id         = var.wls_existing_vcn_id
+  is_idcs_selected            = var.is_idcs_selected
+  idcs_client_secret_id       = var.idcs_client_secret_id
+  use_oci_logging             = var.use_oci_logging
+  use_apm_service             = var.use_apm_service
+  apm_domain_compartment_id   = local.apm_domain_compartment_id
+  use_autoscaling             = var.use_autoscaling
+  ocir_auth_token_id          = var.ocir_auth_token_id
+  add_fss                     = var.add_fss
+  add_load_balancer           = var.add_load_balancer
+  fss_compartment_id          = var.fss_compartment_id == "" ? var.compartment_ocid : var.fss_compartment_id
+  mount_target_compartment_id = var.mount_target_compartment_id == "" ? var.compartment_ocid : var.mount_target_compartment_id
 }
 
 

--- a/terraform/modules/policies/locals.tf
+++ b/terraform/modules/policies/locals.tf
@@ -8,8 +8,8 @@ locals {
   functions_rule   = format("ALL {resource.type = 'fnfunc', resource.compartment.id='%s', %s}", var.compartment_id, var.dynamic_group_rule)
   network_vcn_id   = var.wls_existing_vcn_id != "" ? var.wls_existing_vcn_id : var.vcn_id
 
-  oci_db_connection_string  = trimspace(var.oci_db.oci_db_connection_string)
-  is_oci_db                 = var.oci_db.is_oci_db || local.oci_db_connection_string != ""
+  oci_db_connection_string = trimspace(var.oci_db.oci_db_connection_string)
+  is_oci_db                = var.oci_db.is_oci_db || local.oci_db_connection_string != ""
 
   # This policy with "use instances" verb is needed because there is code in the WebLogic for OCI compute image that updates metadata of the compute instance, when more than one VM nodes are created
   core_policy_statement1 = "Allow dynamic-group ${oci_identity_dynamic_group.wlsc_instance_principal_group.name} to use instances in compartment id ${var.compartment_id}"
@@ -69,15 +69,15 @@ locals {
   autoscaling_statement24 = var.use_autoscaling ? "Allow dynamic-group ${oci_identity_dynamic_group.wlsc_instance_principal_group.name} to manage cloudevents-rules in compartment id ${var.compartment_id}" : ""
   autoscaling_statement25 = var.use_autoscaling ? "Allow dynamic-group ${oci_identity_dynamic_group.wlsc_instance_principal_group.name} to use ons-topics in compartment id ${var.compartment_id}" : ""
   # TODO: Check if we need this.
-  autoscaling_statement26 = var.use_autoscaling ? "Allow dynamic-group ${oci_identity_dynamic_group.wlsc_instance_principal_group.name} to manage log-groups in compartment id ${var.compartment_id}" : ""
-  autoscaling_statement27 = var.use_autoscaling ? length(oci_identity_dynamic_group.wlsc_functions_principal_group) > 0 ? "Allow dynamic-group ${oci_identity_dynamic_group.wlsc_functions_principal_group[0].name} to inspect dynamic-groups in tenancy" : "" : ""
-  autoscaling_statement28 = var.use_autoscaling ? length(oci_identity_dynamic_group.wlsc_functions_principal_group) > 0 ? "Allow dynamic-group ${oci_identity_dynamic_group.wlsc_functions_principal_group[0].name} to manage policies in tenancy" : "" : ""
-  autoscaling_statement29 = var.use_autoscaling ? length(oci_identity_dynamic_group.wlsc_functions_principal_group) > 0 ? "Allow dynamic-group ${oci_identity_dynamic_group.wlsc_functions_principal_group[0].name} to use tag-namespaces in tenancy" : "" : ""
-  autoscaling_atp_policy_statement     = (var.atp_db.is_atp && var.use_autoscaling) ? length(oci_identity_dynamic_group.wlsc_functions_principal_group) > 0 ? "Allow dynamic-group ${oci_identity_dynamic_group.wlsc_functions_principal_group[0].name} to inspect autonomous-transaction-processing-family in compartment id ${var.atp_db.compartment_id}" : "" : ""
-  autoscaling_db_policy_statement     = (local.is_oci_db && var.use_autoscaling) ? length(oci_identity_dynamic_group.wlsc_functions_principal_group) > 0 ? "Allow dynamic-group ${oci_identity_dynamic_group.wlsc_functions_principal_group[0].name} to inspect database-family in compartment id ${var.oci_db.compartment_id}" : "" : ""
-  autoscaling_fss_mount_target_policy_statement = (var.add_fss && var.use_autoscaling) ? length(oci_identity_dynamic_group.wlsc_functions_principal_group) > 0 ? "Allow dynamic-group ${oci_identity_dynamic_group.wlsc_functions_principal_group[0].name} to manage mount-targets in compartment id ${var.fss_compartment_id}" : "" : ""
-  autoscaling_fss_file_system_policy_statement = (var.add_fss && var.use_autoscaling) ? length(oci_identity_dynamic_group.wlsc_functions_principal_group) > 0 ? "Allow dynamic-group ${oci_identity_dynamic_group.wlsc_functions_principal_group[0].name} to manage file-systems in compartment id ${var.fss_compartment_id}" : "" : ""
-  autoscaling_fss_export_sets_policy_statement = (var.add_fss && var.use_autoscaling) ? length(oci_identity_dynamic_group.wlsc_functions_principal_group) > 0 ? "Allow dynamic-group ${oci_identity_dynamic_group.wlsc_functions_principal_group[0].name} to manage export-sets in compartment id ${var.fss_compartment_id}" : "" : ""
+  autoscaling_statement26                       = var.use_autoscaling ? "Allow dynamic-group ${oci_identity_dynamic_group.wlsc_instance_principal_group.name} to manage log-groups in compartment id ${var.compartment_id}" : ""
+  autoscaling_statement27                       = var.use_autoscaling ? length(oci_identity_dynamic_group.wlsc_functions_principal_group) > 0 ? "Allow dynamic-group ${oci_identity_dynamic_group.wlsc_functions_principal_group[0].name} to inspect dynamic-groups in tenancy" : "" : ""
+  autoscaling_statement28                       = var.use_autoscaling ? length(oci_identity_dynamic_group.wlsc_functions_principal_group) > 0 ? "Allow dynamic-group ${oci_identity_dynamic_group.wlsc_functions_principal_group[0].name} to manage policies in tenancy" : "" : ""
+  autoscaling_statement29                       = var.use_autoscaling ? length(oci_identity_dynamic_group.wlsc_functions_principal_group) > 0 ? "Allow dynamic-group ${oci_identity_dynamic_group.wlsc_functions_principal_group[0].name} to use tag-namespaces in tenancy" : "" : ""
+  autoscaling_atp_policy_statement              = (var.atp_db.is_atp && var.use_autoscaling) ? length(oci_identity_dynamic_group.wlsc_functions_principal_group) > 0 ? "Allow dynamic-group ${oci_identity_dynamic_group.wlsc_functions_principal_group[0].name} to inspect autonomous-transaction-processing-family in compartment id ${var.atp_db.compartment_id}" : "" : ""
+  autoscaling_db_policy_statement               = (local.is_oci_db && var.use_autoscaling) ? length(oci_identity_dynamic_group.wlsc_functions_principal_group) > 0 ? "Allow dynamic-group ${oci_identity_dynamic_group.wlsc_functions_principal_group[0].name} to inspect database-family in compartment id ${var.oci_db.compartment_id}" : "" : ""
+  autoscaling_fss_mount_target_policy_statement = (var.add_fss && var.use_autoscaling) ? length(oci_identity_dynamic_group.wlsc_functions_principal_group) > 0 ? "Allow dynamic-group ${oci_identity_dynamic_group.wlsc_functions_principal_group[0].name} to manage mount-targets in compartment id ${var.mount_target_compartment_id}" : "" : ""
+  autoscaling_fss_file_system_policy_statement  = (var.add_fss && var.use_autoscaling) ? length(oci_identity_dynamic_group.wlsc_functions_principal_group) > 0 ? "Allow dynamic-group ${oci_identity_dynamic_group.wlsc_functions_principal_group[0].name} to manage file-systems in compartment id ${var.fss_compartment_id}" : "" : ""
+  autoscaling_fss_export_sets_policy_statement  = (var.add_fss && var.use_autoscaling) ? length(oci_identity_dynamic_group.wlsc_functions_principal_group) > 0 ? "Allow dynamic-group ${oci_identity_dynamic_group.wlsc_functions_principal_group[0].name} to manage export-sets in compartment id ${var.fss_compartment_id}" : "" : ""
 
   autoscaling_statements = compact([local.autoscaling_statement1, local.autoscaling_statement2,
     local.autoscaling_statement3, local.autoscaling_statement4, local.autoscaling_statement5,

--- a/terraform/modules/policies/variables.tf
+++ b/terraform/modules/policies/variables.tf
@@ -28,6 +28,24 @@ variable "network_compartment_id" {
   }
 }
 
+variable "fss_compartment_id" {
+  type        = string
+  description = "The OCID of the compartment where the file system exists"
+  validation {
+    condition     = length(regexall("^ocid1.compartment.*$", var.fss_compartment_id)) > 0
+    error_message = "WLSC-ERROR: The value for fss_compartment_id should start with \"ocid1.compartment.\"."
+  }
+}
+
+variable "mount_target_compartment_id" {
+  type        = string
+  description = "The OCID of the compartment where the mount target exists"
+  validation {
+    condition     = length(regexall("^ocid1.compartment.*$", var.mount_target_compartment_id)) > 0
+    error_message = "WLSC-ERROR: The value for mount_target_compartment_id should start with \"ocid1.compartment.\"."
+  }
+}
+
 variable "vcn_id" {
   type        = string
   description = "The OCID of the VCN where the WebLogic VMs are located"


### PR DESCRIPTION
- Add back the variable fss_compartment_id to the policies module
- Add a new variable, mount_target_compartment_id, to the policies module, and update policies accordingly. Mount target and FSS can be in different compartments now
- Run terraform fmt on affected files