### PR TITLE
JCS-13563 Create instance without bastion fails in Santiago region

### DIFF
--- a/terraform/bastion_variables.tf
+++ b/terraform/bastion_variables.tf
@@ -17,7 +17,7 @@ variable "existing_bastion_instance_id" {
 variable "bastion_instance_shape" {
   type        = string
   description = "Shape of bastion VM instances"
-  default     = "VM.Standard2.1"
+  default     = "VM.Standard.E4.Flex"
 }
 
 # TODO: uncomment this when UI uses control with flex shape


### PR DESCRIPTION
- Change default for bastion shape

Test performed in Santiago region: 
1- Created stack with no bastion, no LB, existing public weblogic subnet. Verified error reading shape of bastion does not happen
2- Created stack with bastion. Verified in the UI that the shape is the new default, and that after stack is created, the bastion has the default (I did not change the  shape in the UI) and it has one OCPU