### PR TITLE
JCS-13565 SRG: Provisioning fails with new vcn, AD subnets, and lb se…

### DIFF
--- a/terraform/modules/validators/validators.tf
+++ b/terraform/modules/validators/validators.tf
@@ -45,9 +45,9 @@ locals {
   vmscripts_zip_bundle_msg      = "WLSC-ERROR: The value for wlsoci vmscripts zip bundle path is not valid. The value must be obsolute path to vmscripts zip bundle."
   validate_vmscripts_zip_bundle = local.invalid_vmscripts_zip_bundle ? local.validators_msg_map[local.vmscripts_zip_bundle_msg] : null
 
-  new_ad_subnets = !var.use_regional_subnet && !var.use_existing_subnets
+  new_ad_subnets                   = !var.use_regional_subnet && !var.use_existing_subnets
   new_ad_subnets_not_supported_msg = "WLSC-ERROR: Creating new AD specific subnets is not supported."
-  new_ad_subnets_not_supported = local.new_ad_subnets ? local.validators_msg_map[local.new_ad_subnets_not_supported_msg] : null
+  new_ad_subnets_not_supported     = local.new_ad_subnets ? local.validators_msg_map[local.new_ad_subnets_not_supported_msg] : null
 
   missing_lb_availability_domains      = !var.use_regional_subnet && var.use_existing_subnets && local.add_new_load_balancer && (var.is_lb_private ? var.lb_availability_domain_name1 == "" : (var.lb_availability_domain_name1 == "" || var.lb_availability_domain_name2 == ""))
   lb_availability_domains_required_msg = "WLSC-ERROR: The values for lb_subnet_1_availability_domain_name and lb_subnet_2_availability_domain_name are required for AD specific subnets."


### PR DESCRIPTION
…t to true

- Add validation for AD-specific new subnets

Tests performed:
1. Tried to create stack with new VCN and AD specific subnets. Verified new error was shown
2. Tried to create stack with existing VCN and new AD specific subnets. Verified new error was shown
3. Created stack with new VCN, regional subnets. Verified provisioning was successful 
4. Created stack with existing VCN, new regional subnets. Verified provisioning was successful
5. Created stack with existing VCN, existing, AD specific subnets. Verified provisioning was successful
6. Created stack with existing VCN, existing, regional subnets. Verified provisioning was successful