### PR TITLE
JCS-13594 Make the decriptions and titles consistent in 12c and 14c s…

### DIFF
--- a/terraform/schema.yaml
+++ b/terraform/schema.yaml
@@ -462,7 +462,7 @@ variables:
     type: string
     title: "WebLogic Server Admin User Name"
     description: "The name of the administrator in the WebLogic Server domain"
-    pattern: "^[a-zA-Z][a-zA-Z0-9]{7,127}$"
+    pattern: "^[a-zA-Z][a-zA-Z0-9_]{7,127}$"
     minLength: 8
     maxLength: 128
     required: true
@@ -487,7 +487,7 @@ variables:
     type: boolean
     default: false
     title: "Configure Ports"
-    description: "Configure the ports for administration server, managed server, and cluster. If not selected, default ports will be used. See <a target="_blank" href="https://docs.oracle.com/en/cloud/paas/weblogic-cloud/user/default-ports.html">Default Ports</a>."
+    description: "Configure the ports for administration server, managed server, and cluster. If not selected, default ports will be used. See <a target=\"_blank\" href=\"https://docs.oracle.com/en/cloud/paas/weblogic-cloud/user/default-ports.html\">Default Ports</a>."
 
   wls_nm_port:
     visible:
@@ -704,7 +704,7 @@ variables:
     type: string
     required: true
     title: "Acknowledge if Existing Network is Validated"
-    description: "Enter YES to confirm if existing Virtual Cloud Network you selected is validated using the network validation script. See <a target="_blank" href="https://docs.oracle.com/pls/topic/lookup?ctx=en/cloud/paas/weblogic-cloud/user&id=oci_network_validate">Validate Existing Network Setup</a>"
+    description: "Enter YES to confirm if existing Virtual Cloud Network you selected is validated using the network validation script. See <a target=\"_blank\" href=\"https://docs.oracle.com/pls/topic/lookup?ctx=en/cloud/paas/weblogic-cloud/user&id=oci_network_validate\">Validate Existing Network Setup</a>"
     pattern: "^[yY][eE][sS]$"
     visible:
       and:
@@ -1449,7 +1449,7 @@ variables:
   create_policies:
     type: boolean
     title: "OCI Policies"
-    description: "Create policies to read Secrets from Vault and manage Autonomous Transaction Processing Database (if applicable). Deselecting this option is for Advanced users only.  Before you deselect the check box, see <a target="_blank" href="https://docs.oracle.com/pls/topic/lookup?ctx=en/cloud/paas/weblogic-cloud&id=WLCUG-GUID-4E2AD7BF-592D-4C2C-AF66-D98CB26379A5">Create Root Policies</a> to create the required groups and relevant policies."
+    description: "Create policies to read Secrets from Vault and manage Autonomous Transaction Processing Database (if applicable). Deselecting this option is for Advanced users only.  Before you deselect the check box, see <a target=\"_blank\" href=\"https://docs.oracle.com/pls/topic/lookup?ctx=en/cloud/paas/weblogic-cloud&id=WLCUG-GUID-4E2AD7BF-592D-4C2C-AF66-D98CB26379A5\">Create Root Policies</a> to create the required groups and relevant policies."
     required: false
     default: true
 
@@ -1487,7 +1487,7 @@ variables:
                 - "Database System"
     type: boolean
     title: "Use Database Connection String"
-    description: "Use database connection string to create a single instance datasource for JRF schemas. You cannot create an Active GridLink or a Multi Data Source using this database connection string. For the database connection string, see <a target="_blank" href="https://docs.oracle.com/en/cloud/paas/weblogic-cloud/user/create-jrf-enabled-domain.html#GUID-6A39A2A7-EF6C-408E-B5C7-C44089A9B134">Configure Database Parameters</a>."
+    description: "Use database connection string to create a single instance datasource for JRF schemas. You cannot create an Active GridLink or a Multi Data Source using this database connection string. For the database connection string, see <a target=\"_blank\" href=\"https://docs.oracle.com/en/cloud/paas/weblogic-cloud/user/create-jrf-enabled-domain.html#GUID-6A39A2A7-EF6C-408E-B5C7-C44089A9B134\">Configure Database Parameters</a>."
     default: false
 
   oci_db_connection_string:
@@ -1563,7 +1563,7 @@ variables:
       compartmentId: ${atp_db_secret_compartment_id}
     required: true
     title: "Validated Secret for Autonomous Database Admin Password"
-    description: "The secret that contains the administration user password in the ATP database. To create secrets, see <a target="_blank" href="https://docs.oracle.com/en/cloud/paas/weblogic-cloud/user/you-begin-oracle-weblogic-cloud.html#GUID-0517A019-4A89-40ED-A568-DD2193733F8B"> Create Secrets for Passwords</a>."
+    description: "The secret that contains the administration user password in the ATP database. To create secrets, see <a target=\"_blank\" href=\"https://docs.oracle.com/en/cloud/paas/weblogic-cloud/user/you-begin-oracle-weblogic-cloud.html#GUID-0517A019-4A89-40ED-A568-DD2193733F8B\"> Create Secrets for Passwords</a>."
 
   atp_db_level:
     visible:
@@ -1883,7 +1883,7 @@ variables:
       compartmentId: ${oci_db_secret_compartment_id}
     required: true
     title: "Validated Secret for OCI DB Admin Password"
-    description: "The secret that contains the database administration password. To create secrets, see <a target="_blank" href="https://docs.oracle.com/en/cloud/paas/weblogic-cloud/user/you-begin-oracle-weblogic-cloud.html#GUID-0517A019-4A89-40ED-A568-DD2193733F8B"> Create Secrets for Passwords</a>."
+    description: "The secret that contains the database administration password. To create secrets, see <a target=\"_blank\" href=\"https://docs.oracle.com/en/cloud/paas/weblogic-cloud/user/you-begin-oracle-weblogic-cloud.html#GUID-0517A019-4A89-40ED-A568-DD2193733F8B\"> Create Secrets for Passwords</a>."
 
   db_vcn_lpg_id:
     visible:
@@ -2001,7 +2001,7 @@ variables:
     minLength: 1
     maxLength: 1024
     title: "IDCS Client ID"
-    description: "The client ID of a confidential application in Identity Cloud Service that is used to create the necessary artifacts in Identity Cloud Service. This application needs to be configured as client, and has to be granted with access to Identity Cloud Service Admin APIs, with Identity Domain Administrator app role. See <a target="_blank" href="https://docs.oracle.com/en/cloud/paas/weblogic-cloud/user/you-begin-oracle-weblogic-cloud.html#GUID-807D5863-04A3-47A3-8D65-443B859B80FD">Create a Confidential Application</a>."
+    description: "The client ID of a confidential application in Identity Cloud Service that is used to create the necessary artifacts in Identity Cloud Service. This application needs to be configured as client, and has to be granted with access to Identity Cloud Service Admin APIs, with Identity Domain Administrator app role. See <a target=\"_blank\" href=\"https://docs.oracle.com/en/cloud/paas/weblogic-cloud/user/you-begin-oracle-weblogic-cloud.html#GUID-807D5863-04A3-47A3-8D65-443B859B80FD\">Create a Confidential Application</a>."
     required: true
 
   idcs_secret_compartment_id:
@@ -2026,7 +2026,7 @@ variables:
     minLength: 1
     maxLength: 1024
     title: "Validated Secret for IDCS Client"
-    description: "The secret that contains the client secret of the confidential application password in IDCS, which is used to create the necessary artifacts in IDCS. To create secrets, see <a target="_blank" href="https://docs.oracle.com/en/cloud/paas/weblogic-cloud/user/you-begin-oracle-weblogic-cloud.html#GUID-0517A019-4A89-40ED-A568-DD2193733F8B"> Create Secrets for Passwords</a>."
+    description: "The secret that contains the client secret of the confidential application password in IDCS, which is used to create the necessary artifacts in IDCS. To create secrets, see <a target=\"_blank\" href=\"https://docs.oracle.com/en/cloud/paas/weblogic-cloud/user/you-begin-oracle-weblogic-cloud.html#GUID-0517A019-4A89-40ED-A568-DD2193733F8B\"> Create Secrets for Passwords</a>."
     required: true
     dependsOn:
       compartmentId: ${idcs_secret_compartment_id}
@@ -2155,7 +2155,7 @@ variables:
     type: boolean
     default: false
     title: "Terms of use"
-    description: "I have reviewed and accept the <a target="_blank" href="https://objectstorage.us-phoenix-1.oraclecloud.com/n/axxu7cichsnt/b/terms/o/wlsoci_ee_terms_and_conditions.txt">Oracle terms of use</a>"
+    description: "I have reviewed and accept the <a target=\"_blank\" href=\"https://objectstorage.us-phoenix-1.oraclecloud.com/n/axxu7cichsnt/b/terms/o/wlsoci_ee_terms_and_conditions.txt\">Oracle terms of use</a>"
     required: true
 
   use_apm_service:

--- a/terraform/schema_14110.yaml
+++ b/terraform/schema_14110.yaml
@@ -460,7 +460,7 @@ variables:
     type: string
     title: "WebLogic Server Admin User Name"
     description: "The name of the administrator in the WebLogic Server domain"
-    pattern: "^[a-zA-Z][a-zA-Z0-9]{7,127}$"
+    pattern: "^[a-zA-Z][a-zA-Z0-9_]{7,127}$"
     minLength: 8
     maxLength: 128
     required: true
@@ -496,7 +496,7 @@ variables:
     type: boolean
     default: false
     title: "Configure Ports"
-    description: "Configure the ports for administration server, managed server, and cluster. If not selected, default ports will be used. See <a target="_blank" href="https://docs.oracle.com/en/cloud/paas/weblogic-cloud/user/default-ports.html">Default Ports</a>."
+    description: "Configure the ports for administration server, managed server, and cluster. If not selected, default ports will be used. See <a target=\"_blank\" href=\"https://docs.oracle.com/en/cloud/paas/weblogic-cloud/user/default-ports.html\">Default Ports</a>."
 
   wls_nm_port:
     visible:
@@ -713,7 +713,7 @@ variables:
     type: string
     required: true
     title: "Acknowledge if Existing Network is Validated"
-    description: "Enter YES to confirm if existing Virtual Cloud Network you selected is validated using the network validation script. See <a target="_blank" href="https://docs.oracle.com/pls/topic/lookup?ctx=en/cloud/paas/weblogic-cloud/user&id=oci_network_validate">Validate Existing Network Setup</a>"
+    description: "Enter YES to confirm if existing Virtual Cloud Network you selected is validated using the network validation script. See <a target=\"_blank\" href=\"https://docs.oracle.com/pls/topic/lookup?ctx=en/cloud/paas/weblogic-cloud/user&id=oci_network_validate\">Validate Existing Network Setup</a>"
     pattern: "^[yY][eE][sS]$"
     visible:
       and:
@@ -1458,7 +1458,7 @@ variables:
   create_policies:
     type: boolean
     title: "OCI Policies"
-    description: "Create policies to read Secrets from Vault and manage Autonomous Transaction Processing Database (if applicable). Deselecting this option is for Advanced users only.  Before you deselect the check box, see <a target="_blank" href="https://docs.oracle.com/pls/topic/lookup?ctx=en/cloud/paas/weblogic-cloud&id=WLCUG-GUID-4E2AD7BF-592D-4C2C-AF66-D98CB26379A5">Create Root Policies</a> to create the required groups and relevant policies."
+    description: "Create policies to read Secrets from Vault and manage Autonomous Transaction Processing Database (if applicable). Deselecting this option is for Advanced users only.  Before you deselect the check box, see <a target=\"_blank\" href=\"https://docs.oracle.com/pls/topic/lookup?ctx=en/cloud/paas/weblogic-cloud&id=WLCUG-GUID-4E2AD7BF-592D-4C2C-AF66-D98CB26379A5\">Create Root Policies</a> to create the required groups and relevant policies."
     required: false
     default: true
 
@@ -1539,7 +1539,7 @@ variables:
     minLength: 1
     maxLength: 1024
     title: "IDCS Client ID"
-    description: "The client ID of a confidential application in Identity Cloud Service that is used to create the necessary artifacts in Identity Cloud Service. This application needs to be configured as client, and has to be granted with access to Identity Cloud Service Admin APIs, with Identity Domain Administrator app role. See <a target="_blank" href="https://docs.oracle.com/en/cloud/paas/weblogic-cloud/user/you-begin-oracle-weblogic-cloud.html#GUID-807D5863-04A3-47A3-8D65-443B859B80FD">Create a Confidential Application</a>."
+    description: "The client ID of a confidential application in Identity Cloud Service that is used to create the necessary artifacts in Identity Cloud Service. This application needs to be configured as client, and has to be granted with access to Identity Cloud Service Admin APIs, with Identity Domain Administrator app role. See <a target=\"_blank\" href=\"https://docs.oracle.com/en/cloud/paas/weblogic-cloud/user/you-begin-oracle-weblogic-cloud.html#GUID-807D5863-04A3-47A3-8D65-443B859B80FD\">Create a Confidential Application</a>."
     required: true
 
   idcs_secret_compartment_id:
@@ -1564,7 +1564,7 @@ variables:
     minLength: 1
     maxLength: 1024
     title: "Validated Secret for IDCS Client"
-    description: "The secret that contains the client secret of the confidential application password in IDCS, which is used to create the necessary artifacts in IDCS. To create secrets, see <a target="_blank" href="https://docs.oracle.com/en/cloud/paas/weblogic-cloud/user/you-begin-oracle-weblogic-cloud.html#GUID-0517A019-4A89-40ED-A568-DD2193733F8B"> Create Secrets for Passwords</a>."
+    description: "The secret that contains the client secret of the confidential application password in IDCS, which is used to create the necessary artifacts in IDCS. To create secrets, see <a target=\"_blank\" href=\"https://docs.oracle.com/en/cloud/paas/weblogic-cloud/user/you-begin-oracle-weblogic-cloud.html#GUID-0517A019-4A89-40ED-A568-DD2193733F8B\"> Create Secrets for Passwords</a>."
     required: true
     dependsOn:
       compartmentId: ${idcs_secret_compartment_id}
@@ -1692,7 +1692,7 @@ variables:
     type: boolean
     default: false
     title: "Terms of use"
-    description: "I have reviewed and accept the <a target="_blank" href="https://objectstorage.us-phoenix-1.oraclecloud.com/n/axxu7cichsnt/b/terms/o/wlsoci_ee_terms_and_conditions.txt">Oracle terms of use</a>"
+    description: "I have reviewed and accept the <a target=\"_blank\" href=\"https://objectstorage.us-phoenix-1.oraclecloud.com/n/axxu7cichsnt/b/terms/o/wlsoci_ee_terms_and_conditions.txt\">Oracle terms of use</a>"
     required: true
 
   use_apm_service:


### PR DESCRIPTION
…chema yaml files

- Escape double quotes in descriptions with URLs to fix parsing issue in ORM
- Add the change for wls_admin_user to accept underscore (_) in the user name. This was accidentally removed

Tests:
1. Created mp bundles for 12.2.1.4 and 14.1.1
2. Created ORM stack with each version. Verified ORM UI did not report any parsing error
3. Verified that you can enter _ for admin user
4. Verified each URL modified  still works