### PR TITLE
Add data & mw ocids to instance metadata

### DIFF
--- a/terraform/modules/compute/wls_compute/wls_compute.tf
+++ b/terraform/modules/compute/wls_compute/wls_compute.tf
@@ -78,10 +78,10 @@ module "wls-instances" {
       log_level            = var.log_level
       mw_vol_mount_point   = lookup(var.volume_map[0], "volume_mount_point")
       mw_vol_device        = lookup(var.volume_map[0], "device")
+      mw_volume            = module.middleware-volume.data_volume_ids[x / var.num_volumes]
       data_vol_mount_point = lookup(var.volume_map[1], "volume_mount_point")
       data_vol_device      = lookup(var.volume_map[1], "device")
       data_volume          = module.data-volume.data_volume_ids[x / var.num_volumes]
-      mw_volume            = module.middleware-volume.data_volume_ids[x / var.num_volumes]
 
       deploy_sample_app                  = var.deploy_sample_app
       domain_dir                         = var.domain_dir

--- a/terraform/modules/compute/wls_compute/wls_compute.tf
+++ b/terraform/modules/compute/wls_compute/wls_compute.tf
@@ -80,6 +80,8 @@ module "wls-instances" {
       mw_vol_device        = lookup(var.volume_map[0], "device")
       data_vol_mount_point = lookup(var.volume_map[1], "volume_mount_point")
       data_vol_device      = lookup(var.volume_map[1], "device")
+      data_volume          = module.data-volume.data_volume_ids[x / var.num_volumes]
+      mw_volume            = module.middleware-volume.data_volume_ids[x / var.num_volumes]
 
       deploy_sample_app                  = var.deploy_sample_app
       domain_dir                         = var.domain_dir


### PR DESCRIPTION
Add data & mw ocids details to instance metadata.
This is required to fetch the Block volume information using Volume ocids during volume mounting.