### PR TITLE
fix JCS-13864 Allow namespace in OCIR Registry User Name

### DIFF
--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -155,7 +155,10 @@ locals {
 
   ocir_namespace = data.oci_objectstorage_namespace.object_namespace.namespace
 
-  ocir_user           = format("%s/%s", local.ocir_namespace, var.ocir_user)
+  ocir_namespace_with_slash = format("%s/",local.ocir_namespace)
+  ocir_user_starts_with = substr(var.ocir_user, 0, length(local.ocir_namespace_with_slash))
+  ocir_user =  local.ocir_user_starts_with == local.ocir_namespace_with_slash ? var.ocir_user :  "${format("%s%s", local.ocir_namespace_with_slash, var.ocir_user)}"
+
   region_keys         = data.oci_identity_regions.all_regions.regions.*.key
   region_names        = data.oci_identity_regions.all_regions.regions.*.name
   ocir_region         = var.ocir_region == "" ? lower(element(local.region_keys, index(local.region_names, lower(var.region)))) : var.ocir_region


### PR DESCRIPTION
Implemented [JCS-13864] - Allow namespace in OCIR Registry User Name

Note: This change is using terraform 0.12 compatible string handling functions.

TEST: PASS.  
Stack Variable: **ocir_user =  ax8cfrmecktw/oracleidentitycloudservice/harshad.vilekar@oracle.com**
1. PASS: stack apply succeeded with autoscaling
2. PASS: metatada verification
    "ocir_user": "ax8cfrmecktw/oracleidentitycloudservice/harshad.vilekar@oracle.com",