### PR TITLE
add validation to check existing stack prefix before provisioning

### DIFF
--- a/builds/build_cli.sh
+++ b/builds/build_cli.sh
@@ -69,6 +69,7 @@ mkdir -p ${SCRIPT_DIR}/binaries/tmpbuild
 create_cli_bundle()
 {
   cp -Rf ${SCRIPT_DIR}/../terraform/modules ${SCRIPT_DIR}/../terraform/edition.tf ${SCRIPT_DIR}/../terraform/*.tf ${SCRIPT_DIR}/../terraform/images ${TMP_BUILD}
+  rm ${TMP_BUILD}/modules/validators/stack_validators.tf
   replace_variables
   (cd ${TMP_BUILD}; zip -r ${SCRIPT_DIR}/binaries/wlsoci-terraform.zip *; rm -Rf ${TMP_BUILD}/*)
 }

--- a/builds/build_cli.sh
+++ b/builds/build_cli.sh
@@ -69,7 +69,6 @@ mkdir -p ${SCRIPT_DIR}/binaries/tmpbuild
 create_cli_bundle()
 {
   cp -Rf ${SCRIPT_DIR}/../terraform/modules ${SCRIPT_DIR}/../terraform/edition.tf ${SCRIPT_DIR}/../terraform/*.tf ${SCRIPT_DIR}/../terraform/images ${TMP_BUILD}
-  rm ${TMP_BUILD}/modules/validators/stack_validators.tf
   replace_variables
   (cd ${TMP_BUILD}; zip -r ${SCRIPT_DIR}/binaries/wlsoci-terraform.zip *; rm -Rf ${TMP_BUILD}/*)
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -350,7 +350,7 @@ module "vcn-peering" {
 module "validators" {
   #depends_on = [module.network-validation]
   source     = "./modules/validators"
-
+  compartment_id             = var.compartment_ocid
   service_name               = var.service_name
   wls_ms_port                = var.wls_ms_extern_port
   wls_ms_ssl_port            = var.wls_ms_extern_ssl_port

--- a/terraform/modules/validators/stack_validators.tf
+++ b/terraform/modules/validators/stack_validators.tf
@@ -1,32 +1,30 @@
 # Copyright (c) 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v1.0 as shown at https://oss.oracle.com/licenses/upl.
-# This validation is applicable only for resource manager stacks. Not applicable for terraform CLI mode.
 
-# list all stacks in any state (active, deleted etc)
-data "oci_resourcemanager_stacks" "all_stacks_in_the_compartment" {
+# The validation fails if any running/stopped compute instances with the display name "<service_name>-wls-0" are present in the stack compartment.
+
+data "oci_core_instances" "wls_running_instances_in_stack_compartment" {
   compartment_id = var.compartment_id
+  display_name = local.instance_name_to_match
+  state = "RUNNING"
 }
 
-# collect id of each stack
-locals {
-  stack_list = data.oci_resourcemanager_stacks.all_stacks_in_the_compartment.stacks
-  num_stacks = length(local.stack_list)
-  stack_ids = [for stack in local.stack_list : { id = stack.id }]
-}
-
-# get details of each stack from the list of stack_ids
-data "oci_resourcemanager_stack" "all_stacks" {
-  count = local.num_stacks
-  #Required
-  stack_id = local.stack_ids[count.index].id
+data "oci_core_instances" "wls_stopped_instances_in_stack_compartment" {
+  compartment_id = var.compartment_id
+  display_name = local.instance_name_to_match
+  state = "STOPPED"
 }
 
 locals {
-  stack_variables = [for stack in data.oci_resourcemanager_stack.all_stacks : { variables = stack.variables }]
-  service_names_used_by_existing_stacks = [for stack_variables in local.stack_variables : lookup(stack_variables.variables, "service_name", "?_not_found_?")]
-  duplicate_service_names_list = [for service_name in local.service_names_used_by_existing_stacks : service_name if service_name == var.service_name]
-  # There will be always one entry for the name of the current stack. Set duplicate to true if there are more than one entries.
-  service_name_already_exists = length(local.duplicate_service_names_list) > 1 ? true : false
-  service_name_already_exists_msg      = "WLSC-ERROR: Another stack with the service_name [${var.service_name}] already exisits in the stack compartment. Try again with a different service name."
+  vnic_prefix = "wls"
+  resource_name_prefix = var.service_name
+  # The host_label value below should match with the host_label of the module wls_compute
+  host_label = "${local.resource_name_prefix}-${local.vnic_prefix}"
+  instance_name_to_match = "${local.host_label}-0"
+  num_running_instances = length(data.oci_core_instances.wls_running_instances_in_stack_compartment.instances)
+  num_stopped_instances = length(data.oci_core_instances.wls_stopped_instances_in_stack_compartment.instances)
+  num_instances = local.num_running_instances + local.num_stopped_instances
+  service_name_already_exists = local.num_instances > 0 ? true : false
+  service_name_already_exists_msg = "WLSC-ERROR: Another compute instance with the name [${local.instance_name_to_match}] already exisits in the stack compartment. Try again with a different service name."
   validate_service_name_is_not_already_used = local.service_name_already_exists ? local.validators_msg_map[local.service_name_already_exists_msg] : null
 }

--- a/terraform/modules/validators/stack_validators.tf
+++ b/terraform/modules/validators/stack_validators.tf
@@ -1,8 +1,11 @@
 # Copyright (c) 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+# If any of the existing stacks is the same stack compartment is already using the same "service_name" as the current stack, then fail the validation.
+# To pass the validation, recreate the stack with a different service name.
+# This is to prevent trying to create another compute instance using the same prefix, which will lead to DNS issues.
 # This validation is applicable only for resource manager stacks. Not applicable for terraform CLI mode.
 
-# list all stacks in any state (active, deleted etc)
 data "oci_resourcemanager_stacks" "all_stacks_in_the_compartment" {
   compartment_id = var.compartment_id
 }

--- a/terraform/modules/validators/stack_validators.tf
+++ b/terraform/modules/validators/stack_validators.tf
@@ -1,18 +1,20 @@
 # Copyright (c) 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v1.0 as shown at https://oss.oracle.com/licenses/upl.
+# This validation is applicable only for resource manager stacks. Not applicable for terraform CLI mode.
 
-# list all stacks in all states (active, deleted etc)
+# list all stacks in any state (active, deleted etc)
 data "oci_resourcemanager_stacks" "all_stacks_in_the_compartment" {
   compartment_id = var.compartment_id
 }
 
+# collect id of each stack
 locals {
   stack_list = data.oci_resourcemanager_stacks.all_stacks_in_the_compartment.stacks
   num_stacks = length(local.stack_list)
   stack_ids = [for stack in local.stack_list : { id = stack.id }]
 }
 
-# get details of each stack
+# get details of each stack from the list of stack_ids
 data "oci_resourcemanager_stack" "all_stacks" {
   count = local.num_stacks
   #Required
@@ -21,8 +23,10 @@ data "oci_resourcemanager_stack" "all_stacks" {
 
 locals {
   stack_variables = [for stack in data.oci_resourcemanager_stack.all_stacks : { variables = stack.variables }]
-  service_names_used_by_existing_stacks = [for stack_variables in local.stack_variables : lookup(stack_variables.variables, "service_name", "?service_name_attribute_not_found?")]
-  service_name_already_exists = contains(local.service_names_used_by_existing_stacks, var.service_name) ? true : false
-  service_name_already_exists_msg      = "WLSC-ERROR: The stack with the service_name [${var.service_name}] already exisits in the stack compartment. Try again with a different service name."
+  service_names_used_by_existing_stacks = [for stack_variables in local.stack_variables : lookup(stack_variables.variables, "service_name", "?_not_found_?")]
+  duplicate_service_names_list = [for service_name in local.service_names_used_by_existing_stacks : service_name if service_name == var.service_name]
+  # There will be always one entry for the name of the current stack. Set duplicate to true if there are more than one entries.
+  service_name_already_exists = length(local.duplicate_service_names_list) > 1 ? true : false
+  service_name_already_exists_msg      = "WLSC-ERROR: Another stack with the service_name [${var.service_name}] already exisits in the stack compartment. Try again with a different service name."
   validate_service_name_is_not_already_used = local.service_name_already_exists ? local.validators_msg_map[local.service_name_already_exists_msg] : null
 }

--- a/terraform/modules/validators/stack_validators.tf
+++ b/terraform/modules/validators/stack_validators.tf
@@ -1,0 +1,28 @@
+# Copyright (c) 2023, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+# list all stacks in all states (active, deleted etc)
+data "oci_resourcemanager_stacks" "all_stacks_in_the_compartment" {
+  compartment_id = var.compartment_id
+}
+
+locals {
+  stack_list = data.oci_resourcemanager_stacks.all_stacks_in_the_compartment.stacks
+  num_stacks = length(local.stack_list)
+  stack_ids = [for stack in local.stack_list : { id = stack.id }]
+}
+
+# get details of each stack
+data "oci_resourcemanager_stack" "all_stacks" {
+  count = local.num_stacks
+  #Required
+  stack_id = local.stack_ids[count.index].id
+}
+
+locals {
+  stack_variables = [for stack in data.oci_resourcemanager_stack.all_stacks : { variables = stack.variables }]
+  service_names_used_by_existing_stacks = [for stack_variables in local.stack_variables : lookup(stack_variables.variables, "service_name", "?service_name_attribute_not_found?")]
+  service_name_already_exists = contains(local.service_names_used_by_existing_stacks, var.service_name) ? true : false
+  service_name_already_exists_msg      = "WLSC-ERROR: The stack with the service_name [${var.service_name}] already exisits in the stack compartment. Try again with a different service name."
+  validate_service_name_is_not_already_used = local.service_name_already_exists ? local.validators_msg_map[local.service_name_already_exists_msg] : null
+}

--- a/terraform/modules/validators/stack_validators.tf
+++ b/terraform/modules/validators/stack_validators.tf
@@ -1,30 +1,32 @@
 # Copyright (c) 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v1.0 as shown at https://oss.oracle.com/licenses/upl.
+# This validation is applicable only for resource manager stacks. Not applicable for terraform CLI mode.
 
-# The validation fails if any running/stopped compute instances with the display name "<service_name>-wls-0" are present in the stack compartment.
-
-data "oci_core_instances" "wls_running_instances_in_stack_compartment" {
+# list all stacks in any state (active, deleted etc)
+data "oci_resourcemanager_stacks" "all_stacks_in_the_compartment" {
   compartment_id = var.compartment_id
-  display_name = local.instance_name_to_match
-  state = "RUNNING"
 }
 
-data "oci_core_instances" "wls_stopped_instances_in_stack_compartment" {
-  compartment_id = var.compartment_id
-  display_name = local.instance_name_to_match
-  state = "STOPPED"
+# collect id of each stack
+locals {
+  stack_list = data.oci_resourcemanager_stacks.all_stacks_in_the_compartment.stacks
+  num_stacks = length(local.stack_list)
+  stack_ids = [for stack in local.stack_list : { id = stack.id }]
+}
+
+# get details of each stack from the list of stack_ids
+data "oci_resourcemanager_stack" "all_stacks" {
+  count = local.num_stacks
+  #Required
+  stack_id = local.stack_ids[count.index].id
 }
 
 locals {
-  vnic_prefix = "wls"
-  resource_name_prefix = var.service_name
-  # The host_label value below should match with the host_label of the module wls_compute
-  host_label = "${local.resource_name_prefix}-${local.vnic_prefix}"
-  instance_name_to_match = "${local.host_label}-0"
-  num_running_instances = length(data.oci_core_instances.wls_running_instances_in_stack_compartment.instances)
-  num_stopped_instances = length(data.oci_core_instances.wls_stopped_instances_in_stack_compartment.instances)
-  num_instances = local.num_running_instances + local.num_stopped_instances
-  service_name_already_exists = local.num_instances > 0 ? true : false
-  service_name_already_exists_msg = "WLSC-ERROR: Another compute instance with the name [${local.instance_name_to_match}] already exisits in the stack compartment. Try again with a different service name."
+  stack_variables = [for stack in data.oci_resourcemanager_stack.all_stacks : { variables = stack.variables }]
+  service_names_used_by_existing_stacks = [for stack_variables in local.stack_variables : lookup(stack_variables.variables, "service_name", "?_not_found_?")]
+  duplicate_service_names_list = [for service_name in local.service_names_used_by_existing_stacks : service_name if service_name == var.service_name]
+  # There will be always one entry for the name of the current stack. Set duplicate to true if there are more than one entries.
+  service_name_already_exists = length(local.duplicate_service_names_list) > 1 ? true : false
+  service_name_already_exists_msg      = "WLSC-ERROR: Another stack with the service_name [${var.service_name}] already exisits in the stack compartment. Try again with a different service name."
   validate_service_name_is_not_already_used = local.service_name_already_exists ? local.validators_msg_map[local.service_name_already_exists_msg] : null
 }

--- a/terraform/modules/validators/variables.tf
+++ b/terraform/modules/validators/variables.tf
@@ -3,7 +3,7 @@
 
 variable "compartment_id" {
   type        = string
-  description = "Compartment for stack resources"
+  description = "The OCID of the compartment where the stack resources are created"
 }
 
 variable "service_name" {

--- a/terraform/modules/validators/variables.tf
+++ b/terraform/modules/validators/variables.tf
@@ -1,6 +1,11 @@
 # Copyright (c) 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v1.0 as shown at https://oss.oracle.com/licenses/upl.
 
+variable "compartment_id" {
+  type        = string
+  description = "Compartment for stack resources"
+}
+
 variable "service_name" {
   type        = string
   description = "Prefix for stack resources"


### PR DESCRIPTION
Issue Fixed:
- [JCS-13837](https://jira.oraclecorp.com/jira/browse/JCS-13837) Enh 35251378 - Script to check existing stack prefix before provisioning

Validation:
- The validation fails if another stack with the service name is already present in the same stack compartment

Limitations:
- Only the stacks in the current stack compartment are checked. Other compartments are not checked. 
- Validation is done for UI mode only. No validation is done for CLI mode.

Tests PASS: 
- PASS: create second stack with the same prefix in the same compartment, and verify the apply fails with the validation error. 
![image](https://github.com/oracle-quickstart/oci-weblogic-server/assets/101137416/ad92e2c7-1892-47c8-98f3-7aebb6afd111)
- PASS: validation succeeds if there is no other stack with the same service_name in the same compartment
- PASS: destroy fails