### PR TITLE
Fix the jira 13945 (#216)

### DIFF
--- a/terraform/modules/compute/wls_compute/locals.tf
+++ b/terraform/modules/compute/wls_compute/locals.tf
@@ -28,6 +28,6 @@ locals {
   db_options            = try(lookup(data.oci_database_db_systems.ocidb_db_systems[0].db_systems[0], "db_system_options", []), [])
   db_storage_management = try(lookup(local.db_options[0], "storage_management", "ASM"), "ASM")
 
-  is_db_deleted = local.apply_JRF ? (local.is_atp_db ? (data.oci_database_autonomous_database.atp_db[0].id == null ? true : false) : (data.oci_database_database.ocidb_database[0].id == null ? true : false)) : false
+  is_db_deleted = local.apply_JRF ? (local.is_atp_db ? (try(data.oci_database_autonomous_database.atp_db[0].id, null) == null ? true : false) : (try(data.oci_database_database.ocidb_database[0].id, null) == null ? true : false)) : false
 
 }


### PR DESCRIPTION
Fix the connection string provisioning issues

1. Created JRF instance with rac database without providing db connecting string.
2. Created JRF instance with rac database with providing db connect string.

(cherry picked from commit a41ddb07e0b6bb156f493b189afd178cee96073f) (cherry picked from commit 7def2c67220eb2e06e4dce5c7edc07c2a7ebe188)