### PR TITLE
Fix bug Certificate on LB is reset in scaling operation

### DIFF
--- a/terraform/modules/lb/backends/lb_backends.tf
+++ b/terraform/modules/lb/backends/lb_backends.tf
@@ -44,6 +44,10 @@ resource "oci_load_balancer_listener" "wls_lb_listener_https" {
     certificate_name        = oci_load_balancer_certificate.demo_certificate[count.index].certificate_name
     verify_peer_certificate = false
   }
+
+  lifecycle {
+    ignore_changes = [ssl_configuration]
+  }
 }
 
 resource "oci_load_balancer_backend" "wls_lb_backend" {


### PR DESCRIPTION
Fixed bug Certificate on LB is reset in scaling operation.
Test
-----

    Create a single VM instance with load balancer.
    Create a new certificate to the load balancer.
        Note that you can generate a keypair from any OCI compute instance with 'openssl req -new -sha256 -newkey rsa:2048 -nodes -keyout testssl.key -x509 -days 365 -out testssl.crt'
        Note that you'll need to add both the certificate and private key pems that are generated to the certificate.
    Associate the certificate you added to the listener for the load balancer.
    Delete the demo certificate that was generated by the Stack from the load balancer.
    Edit the stack and add a node.
    Make sure that new certificate is assigned to the listener.
    Demo certificate will be recreated but not assigned to any.

 The certificate created and added by a customer is not reset, but will still restore the cert created by terraform if it is deleted.

