### PR TITLE
JCS-13959 - validate_vcn_cidr.py always returning errors in bootstrap

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -615,7 +615,7 @@ module "compute" {
   wls_vcn_peering_route_table_attachment_id = local.assign_weblogic_public_ip ? element(flatten(concat(module.vcn-peering[*].wls_vcn_public_route_table_attachment_id, [""])), 0) : element(flatten(concat(module.vcn-peering[*].wls_vcn_private_route_table_attachment_id, [""])), 0)
 
   mount_vcn_id                  = var.mount_target_id != "" ? data.oci_core_subnet.mount_target_existing_subnet[0].vcn_id : ""
-  wls_vcn_cidr                  = var.wls_vcn_cidr != "" ? var.wls_vcn_cidr : element(concat(module.network-vcn.*.vcn_cidr, tolist([""])), 0)
+  wls_vcn_cidr                  = var.wls_vcn_cidr != "" ? var.wls_vcn_cidr : data.oci_core_vcn.wls_vcn[0].cidr_block
   wls_version                   = var.wls_version
   wls_edition                   = var.wls_edition
   allow_manual_domain_extension = var.allow_manual_domain_extension


### PR DESCRIPTION
validate_vcn_cidr.py always returning errors in bootstrap log due to wls_vcn_cidr being empty with existing subnets.

Note that this is essentially a revert to the previous commit. The checkin log for the commit states, "Use customer provided NSGs for existing subnet provisioning". Therefore, I tested with existing subnet and NSGs provided with the reversion of this line change and there were no issues. Other tests in addition to existing subnet with NSGs provided:
1. New VCN.
2. Existing VCN, new subnet
3. Existing subnet with security rules. In each case I tested with IDCS added so the call to validate_vcn_cidr.py would occur. I not only made sure the error no longer appeared, but verified that the metadata value was present and ran validate_vcn_cidr.py by hand.