### PR TITLE
JCS-14035 - Fail to get password expiry date when using connect string

### DIFF
--- a/terraform/modules/validators/oci_db_validators.tf
+++ b/terraform/modules/validators/oci_db_validators.tf
@@ -18,7 +18,7 @@ locals {
   missing_oci_db_compartment_id = (var.is_oci_db && !local.has_oci_db_compartment_id)
   missing_oci_db_database_id    = (var.is_oci_db && !local.has_oci_db_database_id)
 
-  missing_oci_db_pdb_service_name = (var.is_oci_db && !local.has_oci_db_pdb_service_name)
+  missing_oci_db_pdb_service_name = (var.is_oci_db || var.oci_db_connection_string != "") && !local.has_oci_db_pdb_service_name
 
   missing_oci_db_vcn_id = (var.is_oci_db && var.oci_db_existing_vcn_id == "")
 

--- a/terraform/schema.yaml
+++ b/terraform/schema.yaml
@@ -50,6 +50,7 @@ groupings:
       - ${atp_db_password_id}
       - ${atp_db_level}
       - ${use_oci_db_connection_string}
+      - ${oci_db_connection_string}
       - ${oci_db_compartment_id}
       - ${oci_db_dbsystem_id}
       - ${oci_db_network_compartment_id}
@@ -58,7 +59,6 @@ groupings:
       - ${oci_db_dbhome_major_version}
       - ${oci_db_database_id}
       - ${oci_db_pdb_service_name}
-      - ${oci_db_connection_string}
       - ${oci_db_user}
       - ${oci_db_secret_compartment_id}
       - ${oci_db_password_id}
@@ -1853,18 +1853,13 @@ variables:
         - ${orm_create_mode}
         - ${add_JRF}
         - and:
-            - or:
-                - ${create_new_vcn}
-                - not:
-                    - ${use_oci_db_connection_string}
-            - and:
-                - not:
-                    - eq:
-                        - ${oci_db_dbhome_major_version}
-                        - "11"
+            - not:
                 - eq:
-                    - ${db_strategy}
-                    - "Database System"
+                    - ${oci_db_dbhome_major_version}
+                    - "11"
+            - eq:
+                - ${db_strategy}
+                - "Database System"
 
     type: string
     required: true


### PR DESCRIPTION
Bug - Fail to get password expiry date for OPSS user when using connect string

Note that since the DB service name is not guaranteed to include the PDB name ( I proved this by using a connect string w/o the PDB name in it to successfully create a WLS for OCI instance). Therefore, the PDB name must be asked for.

Also note that the validation change added will not be executed, but to limit the scope of the changes I updated the validation only and didn't try to also add in the validator. I suspect that the validation was never added in order to ensure that 11g databases, which don't have a PDB can be allowed.

Tested that when setting a connect string the error occurred. After the fix, with PDB name provided, the error did not occur.
