### PR TITLE
JCS-14046 Support VM.Standard.E5.Flex shape, but not as default shape.

### DIFF
--- a/terraform/modules/compute/wls_compute/validators.tf
+++ b/terraform/modules/compute/wls_compute/validators.tf
@@ -7,12 +7,12 @@ locals {
     #Dummy map to trigger an error in case we detect a validation error.
   }
   is_std_flex_shape                  = var.instance_shape.instanceShape == "VM.Standard.E3.Flex" || var.instance_shape.instanceShape == "VM.Standard.E4.Flex" || var.instance_shape.instanceShape == "VM.Standard3.Flex"
-  invalid_ocpu_count_standard_shape  = local.is_std_flex_shape ? (var.instance_shape.ocpus < 1 || var.instance_shape.ocpus > 64) : false
+  invalid_ocpu_count_standard_shape  = local.is_std_flex_shape ? (var.instance_shape.ocpus < 1 || var.instance_shape.ocpus > 64) : var.instance_shape.instanceShape == "VM.Standard.E5.Flex" ? (var.instance_shape.ocpus < 1 || var.instance_shape.ocpus > 94) : false
   is_optimized_flex_shape            = var.instance_shape.instanceShape == "VM.Optimized3.Flex"
   invalid_ocpu_count_optimized_shape = local.is_optimized_flex_shape ? (var.instance_shape.ocpus < 1 || var.instance_shape.ocpus > 18) : false
 
   #Flex shape validations
-  invalid_standard_flex_shape_ocpus_msg = "WLSC-ERROR: The standard flex instance shape [ VM.Standard.E3.Flex, VM.Standard.E4.Flex, VM.Standard3.Flex ] support maximum 64 ocpus."
+  invalid_standard_flex_shape_ocpus_msg = "WLSC-ERROR: The standard flex instance shapes [ VM.Standard.E3.Flex, VM.Standard.E4.Flex, VM.Standard3.Flex ] support maximum 64 ocpus and VM.Standard.E5.Flex supports a maximum of 94 ocpus."
   validate_standard_flex_shape_ocpus    = local.invalid_ocpu_count_standard_shape ? local.validators_msg_map[local.invalid_standard_flex_shape_ocpus_msg] : null
 
   invalid_optimized_flex_shape_ocpus_msg = "WLSC-ERROR: The VM.Optimized3.Flex instance shape supports maximum 18 ocpus."

--- a/terraform/schema.yaml
+++ b/terraform/schema.yaml
@@ -394,9 +394,9 @@ variables:
   wls_ocpu_count:
     type: integer
     title: "OCPU Count"
-    description: "The number of OCPU count for instances. Only required for VM.Standard.E3.Flex, VM.Standard.E4.Flex, VM.Optimized3.Flex, and  VM.Standard3.Flex Shapes. The maximum number of ocpus for VM.Standard.E3.Flex and VM.Standard.E4.Flex is 64 while VM.Optimized3.Flex shape supports maximum of 18 ocpus. When scaled-out, the changes in OCPU count will apply only to the added nodes."
+    description: "The number of OCPU count for instances. Only required for VM.Standard.E3.Flex, VM.Standard.E4.Flex, VM.Standard.E5.Flex, VM.Optimized3.Flex, and  VM.Standard3.Flex Shapes. The maximum number of ocpus for VM.Standard.E3.Flex, VM.Standard.E4.Flex, and VM.Standard.E5.Flex is 64 while VM.Optimized3.Flex shape supports maximum of 18 ocpus. When scaled-out, the changes in OCPU count will apply only to the added nodes."
     minimum: 1
-    maximum: 64
+    maximum: 94
     multipleOf: 1
     default: 1
     required: true
@@ -410,6 +410,9 @@ variables:
         - eq:
           - ${instance_shape}
           - "VM.Standard.E4.Flex"
+        - eq:
+          - ${instance_shape}
+          - "VM.Standard.E5.Flex"
         - eq:
           - ${instance_shape}
           - "VM.Optimized3.Flex"

--- a/terraform/schema.yaml
+++ b/terraform/schema.yaml
@@ -394,7 +394,7 @@ variables:
   wls_ocpu_count:
     type: integer
     title: "OCPU Count"
-    description: "The number of OCPU count for instances. Only required for VM.Standard.E3.Flex, VM.Standard.E4.Flex, VM.Standard.E5.Flex, VM.Optimized3.Flex, and  VM.Standard3.Flex Shapes. The maximum number of ocpus for VM.Standard.E3.Flex, VM.Standard.E4.Flex, and VM.Standard.E5.Flex is 64 while VM.Optimized3.Flex shape supports maximum of 18 ocpus. When scaled-out, the changes in OCPU count will apply only to the added nodes."
+    description: "The number of OCPU count for instances. Only required for VM.Standard.E3.Flex, VM.Standard.E4.Flex, VM.Standard.E5.Flex, VM.Optimized3.Flex, and  VM.Standard3.Flex Shapes. The maximum number of ocpus for VM.Standard.E3.Flex and VM.Standard.E4.Flex is 64, for VM.Standard.E5.Flex is 94, while VM.Optimized3.Flex shape supports 18. When scaled-out, the changes in OCPU count will apply only to the added nodes."
     minimum: 1
     maximum: 94
     multipleOf: 1

--- a/terraform/schema_14110.yaml
+++ b/terraform/schema_14110.yaml
@@ -392,9 +392,9 @@ variables:
   wls_ocpu_count:
     type: integer
     title: "OCPU Count"
-    description: "The number of OCPU count for instances. Only required for VM.Standard.E3.Flex, VM.Standard.E4.Flex, VM.Optimized3.Flex, and  VM.Standard3.Flex Shapes. The maximum number of ocpus for VM.Standard.E3.Flex and VM.Standard.E4.Flex is 64 while VM.Optimized3.Flex shape supports maximum of 18 ocpus. When scaled-out, the changes in OCPU count will apply only to the added nodes."
+    description: "The number of OCPU count for instances. Only required for VM.Standard.E3.Flex, VM.Standard.E4.Flex, VM.Standard.E5.Flex, VM.Optimized3.Flex, and  VM.Standard3.Flex Shapes. The maximum number of ocpus for VM.Standard.E3.Flex, VM.Standard.E4.Flex, and VM.Standard.E5.Flex is 64 while VM.Optimized3.Flex shape supports maximum of 18 ocpus. When scaled-out, the changes in OCPU count will apply only to the added nodes."
     minimum: 1
-    maximum: 64
+    maximum: 94
     multipleOf: 1
     default: 1
     required: true
@@ -408,6 +408,9 @@ variables:
         - eq:
           - ${instance_shape}
           - "VM.Standard.E4.Flex"
+        - eq:
+          - ${instance_shape}
+          - "VM.Standard.E5.Flex"
         - eq:
           - ${instance_shape}
           - "VM.Optimized3.Flex"

--- a/terraform/schema_14110.yaml
+++ b/terraform/schema_14110.yaml
@@ -392,7 +392,7 @@ variables:
   wls_ocpu_count:
     type: integer
     title: "OCPU Count"
-    description: "The number of OCPU count for instances. Only required for VM.Standard.E3.Flex, VM.Standard.E4.Flex, VM.Standard.E5.Flex, VM.Optimized3.Flex, and  VM.Standard3.Flex Shapes. The maximum number of ocpus for VM.Standard.E3.Flex, VM.Standard.E4.Flex, and VM.Standard.E5.Flex is 64 while VM.Optimized3.Flex shape supports maximum of 18 ocpus. When scaled-out, the changes in OCPU count will apply only to the added nodes."
+    description: "The number of OCPU count for instances. Only required for VM.Standard.E3.Flex, VM.Standard.E4.Flex, VM.Standard.E5.Flex, VM.Optimized3.Flex, and  VM.Standard3.Flex Shapes. The maximum number of ocpus for VM.Standard.E3.Flex and VM.Standard.E4.Flex is 64, for VM.Standard.E5.Flex is 94, while VM.Optimized3.Flex shape supports 18. When scaled-out, the changes in OCPU count will apply only to the added nodes."
     minimum: 1
     maximum: 94
     multipleOf: 1


### PR DESCRIPTION
JCS-14046 Support VM.Standard.E5.Flex shape, but not as default shape.
Testing using E5.Flex shape (requires OL8.8 image):
- 14.1.1.0 JDK11 with IDCS. idcs-sample-app logged into.
- 12.2.1.4 JRF on ATP with IDCS (2 OCPU count). idcs-sample-app logged into.
- 14.1.1.0 JDK8 with IDCS validated cloning.

Testing max cpu utilization (E5.Flex allows 94 ocpu max):
- Using same logic changes in this MR built stack with:
-- max OCPUs for Flex5 to 1
-- max OCPUs for Flex4 to 2
-- Set 2 OCPUs for Flex 5 and ran tf plan. Confirmed validation error fired.
-- Set 3 OCPUs for Flex 4 and ran tf plan. Confirmed validation error fired. This shows no regression in the logic changes.