### PR TITLE
JCS-14023 Status check missing from public subnet provisioning

### DIFF
--- a/terraform/modules/provisioners/provisioning.tf
+++ b/terraform/modules/provisioners/provisioning.tf
@@ -2,7 +2,7 @@
 # Licensed under the Universal Permissive License v1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 resource "null_resource" "status_check" {
-  count      = var.is_bastion_instance_required || var.is_rms_private_endpoint_required ? var.num_vm_instances : 0
+  count      = var.assign_public_ip || var.is_bastion_instance_required || var.is_rms_private_endpoint_required ? var.num_vm_instances : 0
   depends_on = [null_resource.dev_mode_provisioning]
 
   // Connection setup for all WLS instances
@@ -121,7 +121,7 @@ resource "null_resource" "status_check" {
 }
 
 resource "null_resource" "print_service_info" {
-  count      = var.is_bastion_instance_required || var.is_rms_private_endpoint_required ? var.num_vm_instances : 0
+  count      = var.assign_public_ip || var.is_bastion_instance_required || var.is_rms_private_endpoint_required ? var.num_vm_instances : 0
   depends_on = [null_resource.status_check]
 
   // Connection setup for all WLS instances
@@ -146,7 +146,7 @@ resource "null_resource" "print_service_info" {
 }
 
 resource "null_resource" "cleanup" {
-  count      = var.is_bastion_instance_required || var.is_rms_private_endpoint_required ? var.num_vm_instances : 0
+  count      = var.assign_public_ip || var.is_bastion_instance_required || var.is_rms_private_endpoint_required ? var.num_vm_instances : 0
   depends_on = [null_resource.print_service_info]
 
 

--- a/terraform/modules/provisioners/variables.tf
+++ b/terraform/modules/provisioners/variables.tf
@@ -48,11 +48,9 @@ variable "bastion_host_private_key" {
   default     = ""
 }
 
-#TODO: Check if this variable is really needed.
 variable "assign_public_ip" {
   type        = bool
-  description = "Set to true if you want the compute instance to have a public IP in addition to the private ip. Use with caution"
-  default     = true
+  description = "Set to true if the WebLogic compute instances will be created in a public subnet and should have a public IP"
 }
 
 variable "is_bastion_instance_required" {


### PR DESCRIPTION
JCS-14023 Status check missing from public subnet provisioning
Verified status check now showing for public subnet, private endpoint and bastion still showing status check, and that private subnet w/o bastion still does not attempt to get status check. Verified all conditions using both ORM UI and CLI.