### PR TITLE
Block obvious names for WebLogic administrator user and Throttle the …

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -618,6 +618,7 @@ module "compute" {
   wls_server_startup_args   = var.wls_server_startup_args
   wls_existing_vcn_id       = var.wls_existing_vcn_id
 
+  # Secure Production Mode
   configure_secure_mode     = var.configure_secure_mode
   administration_port       = var.administration_port
   ms_administration_port    = var.ms_administration_port

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -623,6 +623,7 @@ module "compute" {
   ms_administration_port    = var.ms_administration_port
   keystore_password_id      = local.keystore_password_id
   root_ca_id                = local.root_ca_id
+  thread_pool_limit         = var.thread_pool_limit
 
   #The following two are for adding a dependency on the peering module
   wls_vcn_peering_dns_resolver_id           = element(flatten(concat(module.vcn-peering[*].wls_vcn_dns_resolver_id, [""])), 0)

--- a/terraform/modules/compute/wls_compute/variables.tf
+++ b/terraform/modules/compute/wls_compute/variables.tf
@@ -187,42 +187,6 @@ variable "is_bastion_instance_required" {
   default     = false
 }
 
-variable "configure_secure_mode" {
-  type        = bool
-  description = "Set to true to configure a secure WebLogic domain"
-}
-
-variable "administration_port" {
-  type        = number
-  description = "The domain-wide administration port to configure a secure WebLogic domain"
-}
-
-variable "ms_administration_port" {
-  type        = number
-  description = "The administration port for managed servers to configure a secure WebLogic domain"
-}
-
-variable "keystore_dir" {
-  type        = string
-  description = "The directory where the pkcs12 keystores will be created in the compute instance when secured production mode is enabled."
-  default     = "/u01/data/keystores"
-}
-
-variable "keystore_password_id" {
-  type        = string
-  description = "The OCID of the vault secret with the password for creating the keystore"
-}
-
-variable "root_ca_id" {
-  type        = string
-  description = "The OCID of the existing root certificate authority to issue the certificates"
-}
-
-variable "thread_pool_limit" {
-  type        = number
-  description = "Shared Capacity For Work Managers"
-}
-
 variable "domain_dir" {
   type        = string
   description = "The directory where the WebLogic domain will be created in the compute instance"
@@ -323,4 +287,41 @@ variable "mp_ucm_listing_resource_version" {
 variable "is_ucm_image" {
   type        = bool
   description = "The metadata info to send it to instance to determine if its ucm image based instance or not"
+}
+
+# All the variables under this comment belong to Secure Production Mode
+variable "configure_secure_mode" {
+  type        = bool
+  description = "Set to true to configure a secure WebLogic domain"
+}
+
+variable "administration_port" {
+  type        = number
+  description = "The domain-wide administration port to configure a secure WebLogic domain"
+}
+
+variable "ms_administration_port" {
+  type        = number
+  description = "The administration port for managed servers to configure a secure WebLogic domain"
+}
+
+variable "keystore_dir" {
+  type        = string
+  description = "The directory where the pkcs12 keystores will be created in the compute instance when secured production mode is enabled."
+  default     = "/u01/data/keystores"
+}
+
+variable "keystore_password_id" {
+  type        = string
+  description = "The OCID of the vault secret with the password for creating the keystore"
+}
+
+variable "root_ca_id" {
+  type        = string
+  description = "The OCID of the existing root certificate authority to issue the certificates"
+}
+
+variable "thread_pool_limit" {
+  type        = number
+  description = "Shared Capacity For Work Managers"
 }

--- a/terraform/modules/compute/wls_compute/variables.tf
+++ b/terraform/modules/compute/wls_compute/variables.tf
@@ -218,6 +218,10 @@ variable "root_ca_id" {
   description = "The OCID of the existing root certificate authority to issue the certificates"
 }
 
+variable "thread_pool_limit" {
+  type        = number
+  description = "Shared Capacity For Work Managers"
+}
 
 variable "domain_dir" {
   type        = string

--- a/terraform/modules/compute/wls_compute/wls_compute.tf
+++ b/terraform/modules/compute/wls_compute/wls_compute.tf
@@ -73,6 +73,7 @@ module "wls-instances" {
       keystore_dir                       = var.keystore_dir
       keystore_password_id               = var.keystore_password_id
       root_ca_id                         = var.root_ca_id
+      thread_pool_limit                  = var.thread_pool_limit
 
       user_data            = data.template_cloudinit_config.config.rendered
       mode                 = var.mode

--- a/terraform/modules/compute/wls_compute/wls_compute.tf
+++ b/terraform/modules/compute/wls_compute/wls_compute.tf
@@ -67,6 +67,8 @@ module "wls-instances" {
       wls_subnet_cidr                    = local.wls_subnet_cidr
       wls_edition                        = var.wls_edition
       is_bastion_instance_required       = var.is_bastion_instance_required
+
+      # Secure Production Mode
       configure_secure_mode              = var.configure_secure_mode
       administration_port                = var.administration_port
       ms_administration_port             = var.ms_administration_port

--- a/terraform/schema.yaml
+++ b/terraform/schema.yaml
@@ -71,6 +71,7 @@ groupings:
       #End of JRF fields
       - ${deploy_sample_app}
       - ${wls_server_startup_args}
+      - ${thread_pool_limit}
       - ${configure_wls_ports}
       - ${administration_port}
       - ${ms_administration_port}
@@ -478,8 +479,9 @@ variables:
     visible: ${orm_create_mode}
     type: string
     title: "WebLogic Server Admin User Name"
-    description: "The name of the administrator in the WebLogic Server domain"
-    pattern: "^[a-zA-Z][a-zA-Z0-9_-]{7,127}$"
+    description: "The name of the administrator in the WebLogic Server domain. The value should be between 8 and 128 characters long and alphanumeric, and can contain underscore (_) and hyphen(-) special characters, and should not be system, admin, administrator, or weblogic."
+    pattern: "^(?!weblogic$|administrator$)[a-zA-Z][a-zA-Z0-9_-]{7,127}$"
+    default: "wls_user"
     minLength: 8
     maxLength: 128
     required: true
@@ -844,6 +846,18 @@ variables:
     required: true
     title: "Existing Root Certificate Authority ID"
     description: "The OCID of the existing root certificate authority to issue the certificates"
+
+  thread_pool_limit:
+    visible:
+      and:
+        - ${orm_create_mode}
+        - and:
+            - ${configure_secure_mode}
+    type: string
+    default: 65536
+    title: "Throttle the thread pool"
+    description: "Shared Capacity For Work Managers"
+    required: true
 
   # WLS Network Configuration
   wls_vcn_name:

--- a/terraform/schema_14110.yaml
+++ b/terraform/schema_14110.yaml
@@ -44,6 +44,7 @@ groupings:
       - ${wls_14c_jdk_version}
       - ${deploy_sample_app}
       - ${wls_server_startup_args}
+      - ${thread_pool_limit}
       - ${configure_wls_ports}
       - ${administration_port}
       - ${ms_administration_port}
@@ -476,8 +477,9 @@ variables:
     visible: ${orm_create_mode}
     type: string
     title: "WebLogic Server Admin User Name"
-    description: "The name of the administrator in the WebLogic Server domain"
-    pattern: "^[a-zA-Z][a-zA-Z0-9_-]{7,127}$"
+    description: "The name of the administrator in the WebLogic Server domain. The value should be between 8 and 128 characters long and alphanumeric, and can contain underscore (_) and hyphen(-) special characters, and should not be system, admin, administrator, or weblogic."
+    pattern: "^(?!weblogic$|administrator$)[a-zA-Z][a-zA-Z0-9_-]{7,127}$"
+    default: "wls_user"
     minLength: 8
     maxLength: 128
     required: true
@@ -854,6 +856,17 @@ variables:
     title: "Existing Root Certificate Authority ID"
     description: "The OCID of the existing root certificate authority to issue the certificates"
 
+  thread_pool_limit:
+    visible:
+      and:
+        - ${orm_create_mode}
+        - and:
+            - ${configure_secure_mode}
+    type: string
+    default: 65536
+    title: "Throttle the thread pool"
+    description: "Shared Capacity For Work Managers"
+    required: true
 
   # WLS Network Configuration
   wls_vcn_name:

--- a/terraform/weblogic_variables.tf
+++ b/terraform/weblogic_variables.tf
@@ -27,10 +27,10 @@ variable "wls_node_count_limit" {
 variable "wls_admin_user" {
   type        = string
   description = "Name of WebLogic administration user"
-  default     = "weblogic"
+  default     = "wls_user"
   validation {
-    condition     = replace(var.wls_admin_user, "/^[a-zA-Z][a-zA-Z0-9_-]{7,127}/", "0") == "0"
-    error_message = "WLSC-ERROR: The value for wls_admin_user should be between 8 and 128 characters long and alphanumeric, and can contain underscore (_) and hyphen(-) special characters."
+    condition     = replace(var.wls_admin_user, "/^[a-zA-Z][a-zA-Z0-9_-]{7,127}/", "0") == "0" && !contains(["system", "admin", "administrator", "weblogic"], var.wls_admin_user)
+    error_message = "WLSC-ERROR: The value for wls_admin_user should be between 8 and 128 characters long and alphanumeric, and can contain underscore (_) and hyphen(-) special characters, and should not be system, admin, administrator, or weblogic."
   }
 }
 
@@ -225,4 +225,10 @@ variable "ms_administration_port" {
   type        = number
   description = "The administration port for managed servers to configure a secure WebLogic domain"
   default     = 9004
+}
+
+variable "thread_pool_limit" {
+  type        = number
+  description = "Shared Capacity For Work Managers"
+  default     = 65536
 }

--- a/terraform/weblogic_variables.tf
+++ b/terraform/weblogic_variables.tf
@@ -197,6 +197,7 @@ variable "deploy_sample_app" {
   default     = true
 }
 
+# All the variables under this comment belong to Secure Production Mode
 variable "configure_secure_mode" {
   type        = bool
   description = "Set to true to configure a secure WebLogic domain"


### PR DESCRIPTION
**Testing**

1. One node secured production mode Non-JRF provisioning is successful.
<img width="1414" alt="Screenshot 2024-02-29 at 9 33 39 PM" src="https://github.com/oracle-quickstart/oci-weblogic-server/assets/148204723/512e249f-c23e-4f63-b5e4-45df3b0ca8bb">

2. Block obvious names for WebLogic administrator user:
    -  Changed the default value of username to "wls_user".
        <img width="940" alt="Screenshot 2024-02-29 at 9 12 32 PM" src="https://github.com/oracle-quickstart/oci-weblogic-server/assets/148204723/2cf08291-5ade-43f1-b26f-d51521e2e199">
    -  When username is given as "weblogic", it is blocked.
        <img width="940" alt="Screenshot 2024-02-29 at 9 12 47 PM" src="https://github.com/oracle-quickstart/oci-weblogic-server/assets/148204723/c2877a21-e3ae-4f7e-a302-5fea059f6a36">
    -  When username is given as "weblogic1", it is accepted.
        <img width="940" alt="Screenshot 2024-02-29 at 9 12 58 PM" src="https://github.com/oracle-quickstart/oci-weblogic-server/assets/148204723/ffc425c8-4a7d-4823-93b5-84c331eb51d2">
    -  Error is thrown when username as weblogic is given, when running through CLI.
       <img width="789" alt="Screenshot 2024-02-29 at 9 16 57 PM" src="https://github.com/oracle-quickstart/oci-weblogic-server/assets/148204723/10d64269-4615-4856-b117-15373ac8b788"> <img width="1405" alt="Screenshot 2024-02-29 at 9 17 15 PM" src="https://github.com/oracle-quickstart/oci-weblogic-server/assets/148204723/36a7b77e-fbd9-4a29-a994-7c3e808edd06">

3. Throttle the thread pool:
    - Throttle the thread pool added to the UI with the default value of 65536.
       <img width="701" alt="Screenshot 2024-02-29 at 9 14 04 PM" src="https://github.com/oracle-quickstart/oci-weblogic-server/assets/148204723/249f0669-cf34-4d62-9b58-ecb5fab9b661">
    - Stack created with the thread_pool_limit of 60000 assigned in tfvars file.
       <img width="794" alt="Screenshot 2024-02-29 at 9 17 56 PM" src="https://github.com/oracle-quickstart/oci-weblogic-server/assets/148204723/7ffc2227-6491-4b52-93e9-6d6ad9fcbbc5">
    - Same is visible in admin console for admin server and managed server.
       <img width="1256" alt="Screenshot 2024-02-29 at 9 36 04 PM" src="https://github.com/oracle-quickstart/oci-weblogic-server/assets/148204723/8e8969ba-2bc1-4144-b569-89e585fd5dc4"> <img width="1256" alt="Screenshot 2024-02-29 at 9 36 16 PM" src="https://github.com/oracle-quickstart/oci-weblogic-server/assets/148204723/6c603c53-3224-475f-93b0-76a3fcb664f2">
