### PR TITLE
Set two weblogic users in the Admin role in WLS for OCI

### DIFF
--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -186,9 +186,11 @@ locals {
   add_existing_rms_private_endpoint = local.is_rms_private_endpoint_required && var.add_rms_private_endpoint == "Use Existing Resource Manager Endpoint" ? true : false
 
   # Secured Production Mode
-  wls_admin_port            = var.configure_secure_mode ? var.administration_port : var.wls_admin_port
-  keystore_password_id      = var.configure_secure_mode ? var.keystore_password_id : ""
-  root_ca_id                = var.configure_secure_mode ? var.root_ca_id : ""
-  wls_domain_configuration  = var.configure_secure_mode ? "Secured Production Mode" : "Production Mode"
-  wls_extern_ssl_admin_port = var.configure_secure_mode ? var.administration_port : var.wls_extern_ssl_admin_port
+  wls_admin_port                    = var.configure_secure_mode ? var.administration_port : var.wls_admin_port
+  keystore_password_id              = var.configure_secure_mode ? var.keystore_password_id : ""
+  root_ca_id                        = var.configure_secure_mode ? var.root_ca_id : ""
+  wls_domain_configuration          = var.configure_secure_mode ? "Secured Production Mode" : "Production Mode"
+  wls_extern_ssl_admin_port         = var.configure_secure_mode ? var.administration_port : var.wls_extern_ssl_admin_port
+  wls_admin_user                    = var.configure_secure_mode ? var.wls_primary_admin_user : var.wls_admin_user
+  wls_secondary_admin_password_id   = var.configure_secure_mode ? var.wls_secondary_admin_password_id : "ocid1.vaultsecret."
 }

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -192,5 +192,5 @@ locals {
   wls_domain_configuration          = var.configure_secure_mode ? "Secured Production Mode" : "Production Mode"
   wls_extern_ssl_admin_port         = var.configure_secure_mode ? var.administration_port : var.wls_extern_ssl_admin_port
   wls_admin_user                    = var.configure_secure_mode ? var.wls_primary_admin_user : var.wls_admin_user
-  wls_secondary_admin_password_id   = var.configure_secure_mode ? var.wls_secondary_admin_password_id : "ocid1.vaultsecret."
+  wls_secondary_admin_password_id   = var.configure_secure_mode ? var.wls_secondary_admin_password_id : ""
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -599,7 +599,7 @@ module "compute" {
   tf_script_version         = var.tf_script_version
   use_regional_subnet       = local.use_regional_subnet
   wls_14c_jdk_version       = var.wls_14c_jdk_version
-  wls_admin_user            = var.wls_admin_user
+  wls_admin_user            = local.wls_admin_user
   wls_admin_password_id     = var.wls_admin_password_id
   wls_admin_server_name     = format("%s_adminserver", local.service_name_prefix)
   wls_ms_server_name        = format("%s_server_", local.service_name_prefix)
@@ -619,14 +619,14 @@ module "compute" {
   wls_existing_vcn_id       = var.wls_existing_vcn_id
 
   # Secure Production Mode
-  configure_secure_mode     = var.configure_secure_mode
-  administration_port       = var.administration_port
-  ms_administration_port    = var.ms_administration_port
-  keystore_password_id      = local.keystore_password_id
-  root_ca_id                = local.root_ca_id
-  thread_pool_limit         = var.thread_pool_limit
-  wls_admin_user_1          = var.wls_admin_user_1
-  wls_admin_password_id_1   = var.wls_admin_password_id_1
+  configure_secure_mode              = var.configure_secure_mode
+  administration_port                = var.administration_port
+  ms_administration_port             = var.ms_administration_port
+  keystore_password_id               = local.keystore_password_id
+  root_ca_id                         = local.root_ca_id
+  thread_pool_limit                  = var.thread_pool_limit
+  wls_secondary_admin_user           = var.wls_secondary_admin_user
+  wls_secondary_admin_password_id    = local.wls_secondary_admin_password_id
 
   #The following two are for adding a dependency on the peering module
   wls_vcn_peering_dns_resolver_id           = element(flatten(concat(module.vcn-peering[*].wls_vcn_dns_resolver_id, [""])), 0)

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -625,6 +625,8 @@ module "compute" {
   keystore_password_id      = local.keystore_password_id
   root_ca_id                = local.root_ca_id
   thread_pool_limit         = var.thread_pool_limit
+  wls_admin_user_1          = var.wls_admin_user_1
+  wls_admin_password_id_1   = var.wls_admin_password_id_1
 
   #The following two are for adding a dependency on the peering module
   wls_vcn_peering_dns_resolver_id           = element(flatten(concat(module.vcn-peering[*].wls_vcn_dns_resolver_id, [""])), 0)

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -469,9 +469,11 @@ module "validators" {
   use_marketplace_image  = var.use_marketplace_image
   wls_edition            = var.wls_edition
 
-  configure_secure_mode  = var.configure_secure_mode
-  keystore_password_id   = local.keystore_password_id
-  root_ca_id             = local.root_ca_id
+  # Secure Production Mode
+  configure_secure_mode           = var.configure_secure_mode
+  keystore_password_id            = local.keystore_password_id
+  root_ca_id                      = local.root_ca_id
+  wls_secondary_admin_password_id = local.wls_secondary_admin_password_id
 }
 
 module "fss" {

--- a/terraform/modules/compute/wls_compute/wls_compute.tf
+++ b/terraform/modules/compute/wls_compute/wls_compute.tf
@@ -76,8 +76,8 @@ module "wls-instances" {
       keystore_password_id               = var.keystore_password_id
       root_ca_id                         = var.root_ca_id
       thread_pool_limit                  = var.thread_pool_limit
-      wls_admin_user_1                   = var.wls_admin_user_1
-      wls_admin_password_ocid_1          = var.wls_admin_password_id_1
+      wls_secondary_admin_user           = var.wls_secondary_admin_user
+      wls_secondary_admin_password_ocid  = var.wls_secondary_admin_password_id
 
       user_data            = data.template_cloudinit_config.config.rendered
       mode                 = var.mode

--- a/terraform/modules/compute/wls_compute/wls_compute.tf
+++ b/terraform/modules/compute/wls_compute/wls_compute.tf
@@ -76,6 +76,8 @@ module "wls-instances" {
       keystore_password_id               = var.keystore_password_id
       root_ca_id                         = var.root_ca_id
       thread_pool_limit                  = var.thread_pool_limit
+      wls_admin_user_1                   = var.wls_admin_user_1
+      wls_admin_password_ocid_1          = var.wls_admin_password_id_1
 
       user_data            = data.template_cloudinit_config.config.rendered
       mode                 = var.mode

--- a/terraform/modules/compute/wls_compute/wls_variables.tf
+++ b/terraform/modules/compute/wls_compute/wls_variables.tf
@@ -254,8 +254,4 @@ variable "wls_secondary_admin_user" {
 variable "wls_secondary_admin_password_id" {
   type        = string
   description = "The OCID of the vault secret with the password for secondary WebLogic administration user"
-  validation {
-    condition     = length(regexall("^ocid1.vaultsecret.", var.wls_secondary_admin_password_id)) > 0
-    error_message = "WLSC-ERROR: The value for wls_secondary_admin_password_id should start with \"ocid1.vaultsecret.\"."
-  }
 }

--- a/terraform/modules/compute/wls_compute/wls_variables.tf
+++ b/terraform/modules/compute/wls_compute/wls_variables.tf
@@ -14,9 +14,10 @@ variable "wls_edition" {
 variable "wls_admin_user" {
   type        = string
   description = "The name of the admin user that will be added to the WebLogic domain"
+  default     = "wls_user"
   validation {
-    condition     = replace(var.wls_admin_user, "/^[a-zA-Z][a-zA-Z0-9_-]{7,127}/", "0") == "0"
-    error_message = "WLSC-ERROR: The value for wls_admin_user should be between 8 and 128 characters long and alphanumeric, and can contain underscore (_) and hyphen(-) special characters."
+    condition     = replace(var.wls_admin_user, "/^[a-zA-Z][a-zA-Z0-9_-]{7,127}/", "0") == "0" && !contains(["system", "admin", "administrator", "weblogic"], var.wls_admin_user)
+    error_message = "WLSC-ERROR: The value for wls_admin_user should be between 8 and 128 characters long and alphanumeric, and can contain underscore (_) and hyphen(-) special characters, and should not be system, admin, administrator, or weblogic."
   }
 }
 
@@ -226,5 +227,25 @@ variable "wls_version_to_rcu_component_list_map" {
   default = {
     "12.2.1.3" = "MDS,WLS,STB,IAU_APPEND,IAU_VIEWER,UCSUMS,IAU,OPSS"
     "12.2.1.4" = "MDS,WLS,STB,IAU_APPEND,IAU_VIEWER,UCSUMS,IAU,OPSS"
+  }
+}
+
+# All variables under this comment belong to secure production mode
+variable "wls_admin_user_1" {
+  type        = string
+  description = "Name of second WebLogic administration user"
+  default     = "wls_user_1"
+  validation {
+    condition     = replace(var.wls_admin_user_1, "/^[a-zA-Z][a-zA-Z0-9_-]{7,127}/", "0") == "0" && !contains(["system", "admin", "administrator", "weblogic"], var.wls_admin_user_1)
+    error_message = "WLSC-ERROR: The value for wls_admin_user_1 should be between 8 and 128 characters long and alphanumeric, and can contain underscore (_) and hyphen(-) special characters, and should not be system, admin, administrator, or weblogic."
+  }
+}
+
+variable "wls_admin_password_id_1" {
+  type        = string
+  description = "The OCID of the vault secret with the password for second WebLogic administration user"
+  validation {
+    condition     = length(regexall("^ocid1.vaultsecret.", var.wls_admin_password_id_1)) > 0
+    error_message = "WLSC-ERROR: The value for wls_admin_password_id_1 should start with \"ocid1.vaultsecret.\"."
   }
 }

--- a/terraform/modules/compute/wls_compute/wls_variables.tf
+++ b/terraform/modules/compute/wls_compute/wls_variables.tf
@@ -13,11 +13,11 @@ variable "wls_edition" {
 
 variable "wls_admin_user" {
   type        = string
-  description = "The name of the admin user that will be added to the WebLogic domain"
-  default     = "wls_user"
+  description = "Name of WebLogic administration user"
+  default     = "weblogic"
   validation {
-    condition     = replace(var.wls_admin_user, "/^[a-zA-Z][a-zA-Z0-9_-]{7,127}/", "0") == "0" && !contains(["system", "admin", "administrator", "weblogic"], var.wls_admin_user)
-    error_message = "WLSC-ERROR: The value for wls_admin_user should be between 8 and 128 characters long and alphanumeric, and can contain underscore (_) and hyphen(-) special characters, and should not be system, admin, administrator, or weblogic."
+    condition     = replace(var.wls_admin_user, "/^[a-zA-Z][a-zA-Z0-9_-]{7,127}/", "0") == "0"
+    error_message = "WLSC-ERROR: The value for wls_admin_user should be between 8 and 128 characters long and alphanumeric, and can contain underscore (_) and hyphen(-) special characters."
   }
 }
 
@@ -231,21 +231,31 @@ variable "wls_version_to_rcu_component_list_map" {
 }
 
 # All variables under this comment belong to secure production mode
-variable "wls_admin_user_1" {
+variable "wls_primary_admin_user" {
   type        = string
-  description = "Name of second WebLogic administration user"
-  default     = "wls_user_1"
+  description = "Name of primary WebLogic administration user"
+  default     = "wls_user"
   validation {
-    condition     = replace(var.wls_admin_user_1, "/^[a-zA-Z][a-zA-Z0-9_-]{7,127}/", "0") == "0" && !contains(["system", "admin", "administrator", "weblogic"], var.wls_admin_user_1)
-    error_message = "WLSC-ERROR: The value for wls_admin_user_1 should be between 8 and 128 characters long and alphanumeric, and can contain underscore (_) and hyphen(-) special characters, and should not be system, admin, administrator, or weblogic."
+    condition     = replace(var.wls_primary_admin_user, "/^[a-zA-Z][a-zA-Z0-9_-]{7,127}/", "0") == "0" && !contains(["system", "admin", "administrator", "weblogic"], var.wls_primary_admin_user)
+    error_message = "WLSC-ERROR: The value for wls_primary_admin_user should be between 8 and 128 characters long and alphanumeric, and can contain underscore (_) and hyphen(-) special characters, and should not be system, admin, administrator, or weblogic."
   }
 }
 
-variable "wls_admin_password_id_1" {
+variable "wls_secondary_admin_user" {
   type        = string
-  description = "The OCID of the vault secret with the password for second WebLogic administration user"
+  description = "Name of secondary WebLogic administration user"
+  default     = "wls_user_1"
   validation {
-    condition     = length(regexall("^ocid1.vaultsecret.", var.wls_admin_password_id_1)) > 0
-    error_message = "WLSC-ERROR: The value for wls_admin_password_id_1 should start with \"ocid1.vaultsecret.\"."
+    condition     = replace(var.wls_secondary_admin_user, "/^[a-zA-Z][a-zA-Z0-9_-]{7,127}/", "0") == "0" && !contains(["system", "admin", "administrator", "weblogic"], var.wls_secondary_admin_user)
+    error_message = "WLSC-ERROR: The value for wls_secondary_admin_user should be between 8 and 128 characters long and alphanumeric, and can contain underscore (_) and hyphen(-) special characters, and should not be system, admin, administrator, or weblogic."
+  }
+}
+
+variable "wls_secondary_admin_password_id" {
+  type        = string
+  description = "The OCID of the vault secret with the password for secondary WebLogic administration user"
+  validation {
+    condition     = length(regexall("^ocid1.vaultsecret.", var.wls_secondary_admin_password_id)) > 0
+    error_message = "WLSC-ERROR: The value for wls_secondary_admin_password_id should start with \"ocid1.vaultsecret.\"."
   }
 }

--- a/terraform/modules/validators/validators.tf
+++ b/terraform/modules/validators/validators.tf
@@ -69,4 +69,9 @@ locals {
   root_ca_id_required_msg     = "WLSC-ERROR: The value for root_ca_id is required when enabling secure production mode."
   validate_missing_root_ca_id = local.missing_root_ca_id ? local.validators_msg_map[local.root_ca_id_required_msg] : null
 
+  missing_wls_secondary_admin_password_id              = var.configure_secure_mode && var.wls_secondary_admin_password_id == ""
+  missing_wls_secondary_admin_password_id_required_msg = "WLSC-ERROR: The value for wls_secondary_admin_password_id is required when enabling secure production mode"
+  invalid_wls_secondary_admin_password_id              = var.configure_secure_mode && length(regexall("^ocid1.vaultsecret.", var.wls_secondary_admin_password_id)) > 0
+  invalid_wls_secondary_admin_password_id_required_msg = "WLSC-ERROR: The value for wls_secondary_admin_password_id should start with \"ocid1.vaultsecret.\""
+  validate_wls_secondary_admin_password_id             = local.missing_wls_secondary_admin_password_id ? local.validators_msg_map[local.missing_wls_secondary_admin_password_id_required_msg] : (local.invalid_wls_secondary_admin_password_id ? local.validators_msg_map[local.invalid_wls_secondary_admin_password_id_required_msg] : null)
 }

--- a/terraform/modules/validators/validators.tf
+++ b/terraform/modules/validators/validators.tf
@@ -71,7 +71,7 @@ locals {
 
   missing_wls_secondary_admin_password_id              = var.configure_secure_mode && var.wls_secondary_admin_password_id == ""
   missing_wls_secondary_admin_password_id_required_msg = "WLSC-ERROR: The value for wls_secondary_admin_password_id is required when enabling secure production mode"
-  invalid_wls_secondary_admin_password_id              = var.configure_secure_mode && length(regexall("^ocid1.vaultsecret.", var.wls_secondary_admin_password_id)) > 0
+  invalid_wls_secondary_admin_password_id              = var.configure_secure_mode && length(regexall("^ocid1.vaultsecret.", var.wls_secondary_admin_password_id)) <= 0
   invalid_wls_secondary_admin_password_id_required_msg = "WLSC-ERROR: The value for wls_secondary_admin_password_id should start with \"ocid1.vaultsecret.\""
   validate_wls_secondary_admin_password_id             = local.missing_wls_secondary_admin_password_id ? local.validators_msg_map[local.missing_wls_secondary_admin_password_id_required_msg] : (local.invalid_wls_secondary_admin_password_id ? local.validators_msg_map[local.invalid_wls_secondary_admin_password_id_required_msg] : null)
 }

--- a/terraform/modules/validators/variables.tf
+++ b/terraform/modules/validators/variables.tf
@@ -534,6 +534,7 @@ variable "tf_script_version" {
   description = "The version of the provisioning scripts located in the OCI image used to create the WebLogic compute instances"
 }
 
+# All varaibles under this comment belong to secure production mode
 variable "configure_secure_mode" {
   type        = bool
   description = "Set to true to configure a secure WebLogic domain"
@@ -547,4 +548,9 @@ variable "keystore_password_id" {
 variable "root_ca_id" {
   type        = string
   description = "The OCID of the existing root certificate authority to issue the certificates"
+}
+
+variable "wls_secondary_admin_password_id" {
+  type        = string
+  description = "The OCID of the vault secret with the password for secondary WebLogic administration user"
 }

--- a/terraform/schema.yaml
+++ b/terraform/schema.yaml
@@ -39,6 +39,8 @@ groupings:
       - ${wls_admin_user}
       - ${wls_admin_secret_compartment_id}
       - ${wls_admin_password_id}
+      - ${wls_admin_user_1}
+      - ${wls_admin_password_id_1}
       - ${keystore_password_id}
       - ${root_ca_id}
       - ${add_JRF}
@@ -858,6 +860,32 @@ variables:
     title: "Throttle the thread pool"
     description: "Shared Capacity For Work Managers"
     required: true
+
+  wls_admin_user_1:
+    visible:
+      and:
+        - ${orm_create_mode}
+        - ${configure_secure_mode}
+    type: string
+    title: "WebLogic Server Admin User Name"
+    description: "The name of the second administrator in the WebLogic Server domain. The value should be between 8 and 128 characters long and alphanumeric, and can contain underscore (_) and hyphen(-) special characters, and should not be system, admin, administrator, or weblogic."
+    pattern: "^(?!weblogic$|administrator$)[a-zA-Z][a-zA-Z0-9_-]{7,127}$"
+    default: "wls_user_1"
+    minLength: 8
+    maxLength: 128
+    required: true
+
+  wls_admin_password_id_1:
+    visible:
+      and:
+        - ${orm_create_mode}
+        - ${configure_secure_mode}
+    type: "oci:kms:secret:id"
+    title: "Validated Secret for WebLogic Server Admin Password"
+    description: "The secret that contains the administration password of the second administrator in the WebLogic Server domain. Use a WebLogic Administrator password that starts with a letter, is between 8 and 30 characters long, contains at least one number, and, optionally, any number of the special characters ($ # _). For example, Ach1z0#d. To create secrets, see <a target=\"_blank\" href=\"https://docs.oracle.com/en/cloud/paas/weblogic-cloud/user/you-begin-oracle-weblogic-cloud.html#GUID-0517A019-4A89-40ED-A568-DD2193733F8B\">Create Secrets for Passwords</a>."
+    required: true
+    dependsOn:
+      compartmentId: ${wls_admin_secret_compartment_id}
 
   # WLS Network Configuration
   wls_vcn_name:

--- a/terraform/schema.yaml
+++ b/terraform/schema.yaml
@@ -37,10 +37,11 @@ groupings:
   - title: "WebLogic Domain Configuration"
     variables:
       - ${wls_admin_user}
+      - ${wls_primary_admin_user}
       - ${wls_admin_secret_compartment_id}
       - ${wls_admin_password_id}
-      - ${wls_admin_user_1}
-      - ${wls_admin_password_id_1}
+      - ${wls_secondary_admin_user}
+      - ${wls_secondary_admin_password_id}
       - ${keystore_password_id}
       - ${root_ca_id}
       - ${add_JRF}
@@ -478,12 +479,16 @@ variables:
     required: true
 
   wls_admin_user:
-    visible: ${orm_create_mode}
+    visible:
+      and:
+        - ${orm_create_mode}
+        - not:
+            - ${configure_secure_mode}
     type: string
     title: "WebLogic Server Admin User Name"
-    description: "The name of the administrator in the WebLogic Server domain. The value should be between 8 and 128 characters long and alphanumeric, and can contain underscore (_) and hyphen(-) special characters, and should not be system, admin, administrator, or weblogic."
-    pattern: "^(?!weblogic$|administrator$)[a-zA-Z][a-zA-Z0-9_-]{7,127}$"
-    default: "wls_user"
+    description: "The name of the administrator in the WebLogic Server domain. The value should be between 8 and 128 characters long and alphanumeric, and can contain underscore (_) and hyphen(-) special characters."
+    pattern: "^[a-zA-Z][a-zA-Z0-9_-]{7,127}$"
+    default: "weblogic"
     minLength: 8
     maxLength: 128
     required: true
@@ -861,28 +866,42 @@ variables:
     description: "Shared Capacity For Work Managers"
     required: true
 
-  wls_admin_user_1:
+  wls_primary_admin_user:
     visible:
       and:
         - ${orm_create_mode}
         - ${configure_secure_mode}
     type: string
     title: "WebLogic Server Admin User Name"
-    description: "The name of the second administrator in the WebLogic Server domain. The value should be between 8 and 128 characters long and alphanumeric, and can contain underscore (_) and hyphen(-) special characters, and should not be system, admin, administrator, or weblogic."
+    description: "The name of the primary administrator in the WebLogic Server domain. The value should be between 8 and 128 characters long and alphanumeric, and can contain underscore (_) and hyphen(-) special characters, and should not be system, admin, administrator, or weblogic."
+    pattern: "^(?!weblogic$|administrator$)[a-zA-Z][a-zA-Z0-9_-]{7,127}$"
+    default: "wls_user"
+    minLength: 8
+    maxLength: 128
+    required: true
+
+  wls_secondary_admin_user:
+    visible:
+      and:
+        - ${orm_create_mode}
+        - ${configure_secure_mode}
+    type: string
+    title: "WebLogic Server Admin User Name"
+    description: "The name of the secondary administrator in the WebLogic Server domain. The value should be between 8 and 128 characters long and alphanumeric, and can contain underscore (_) and hyphen(-) special characters, and should not be system, admin, administrator, or weblogic."
     pattern: "^(?!weblogic$|administrator$)[a-zA-Z][a-zA-Z0-9_-]{7,127}$"
     default: "wls_user_1"
     minLength: 8
     maxLength: 128
     required: true
 
-  wls_admin_password_id_1:
+  wls_secondary_admin_password_id:
     visible:
       and:
         - ${orm_create_mode}
         - ${configure_secure_mode}
     type: "oci:kms:secret:id"
     title: "Validated Secret for WebLogic Server Admin Password"
-    description: "The secret that contains the administration password of the second administrator in the WebLogic Server domain. Use a WebLogic Administrator password that starts with a letter, is between 8 and 30 characters long, contains at least one number, and, optionally, any number of the special characters ($ # _). For example, Ach1z0#d. To create secrets, see <a target=\"_blank\" href=\"https://docs.oracle.com/en/cloud/paas/weblogic-cloud/user/you-begin-oracle-weblogic-cloud.html#GUID-0517A019-4A89-40ED-A568-DD2193733F8B\">Create Secrets for Passwords</a>."
+    description: "The secret that contains the administration password of the secondary administrator in the WebLogic Server domain. Use a WebLogic Administrator password that starts with a letter, is between 8 and 30 characters long, contains at least one number, and, optionally, any number of the special characters ($ # _). For example, Ach1z0#d. To create secrets, see <a target=\"_blank\" href=\"https://docs.oracle.com/en/cloud/paas/weblogic-cloud/user/you-begin-oracle-weblogic-cloud.html#GUID-0517A019-4A89-40ED-A568-DD2193733F8B\">Create Secrets for Passwords</a>."
     required: true
     dependsOn:
       compartmentId: ${wls_admin_secret_compartment_id}

--- a/terraform/schema_14110.yaml
+++ b/terraform/schema_14110.yaml
@@ -37,10 +37,11 @@ groupings:
   - title: "WebLogic Domain Configuration"
     variables:
       - ${wls_admin_user}
+      - ${wls_primary_admin_user}
       - ${wls_admin_secret_compartment_id}
       - ${wls_admin_password_id}
-      - ${wls_admin_user_1}
-      - ${wls_admin_password_id_1}
+      - ${wls_secondary_admin_user}
+      - ${wls_secondary_admin_password_id}
       - ${keystore_password_id}
       - ${root_ca_id}
       - ${wls_14c_jdk_version}
@@ -476,12 +477,16 @@ variables:
     required: true
 
   wls_admin_user:
-    visible: ${orm_create_mode}
+    visible:
+      and:
+        - ${orm_create_mode}
+        - not:
+            - ${configure_secure_mode}
     type: string
     title: "WebLogic Server Admin User Name"
-    description: "The name of the administrator in the WebLogic Server domain. The value should be between 8 and 128 characters long and alphanumeric, and can contain underscore (_) and hyphen(-) special characters, and should not be system, admin, administrator, or weblogic."
-    pattern: "^(?!weblogic$|administrator$)[a-zA-Z][a-zA-Z0-9_-]{7,127}$"
-    default: "wls_user"
+    description: "The name of the administrator in the WebLogic Server domain. The value should be between 8 and 128 characters long and alphanumeric, and can contain underscore (_) and hyphen(-) special characters."
+    pattern: "^[a-zA-Z][a-zA-Z0-9_-]{7,127}$"
+    default: "weblogic"
     minLength: 8
     maxLength: 128
     required: true
@@ -870,28 +875,42 @@ variables:
     description: "Shared Capacity For Work Managers"
     required: true
 
-  wls_admin_user_1:
+  wls_primary_admin_user:
     visible:
       and:
         - ${orm_create_mode}
         - ${configure_secure_mode}
     type: string
     title: "WebLogic Server Admin User Name"
-    description: "The name of the second administrator in the WebLogic Server domain. The value should be between 8 and 128 characters long and alphanumeric, and can contain underscore (_) and hyphen(-) special characters, and should not be system, admin, administrator, or weblogic."
+    description: "The name of the primary administrator in the WebLogic Server domain. The value should be between 8 and 128 characters long and alphanumeric, and can contain underscore (_) and hyphen(-) special characters, and should not be system, admin, administrator, or weblogic."
+    pattern: "^(?!weblogic$|administrator$)[a-zA-Z][a-zA-Z0-9_-]{7,127}$"
+    default: "wls_user"
+    minLength: 8
+    maxLength: 128
+    required: true
+
+  wls_secondary_admin_user:
+    visible:
+      and:
+        - ${orm_create_mode}
+        - ${configure_secure_mode}
+    type: string
+    title: "WebLogic Server Admin User Name"
+    description: "The name of the secondary administrator in the WebLogic Server domain. The value should be between 8 and 128 characters long and alphanumeric, and can contain underscore (_) and hyphen(-) special characters, and should not be system, admin, administrator, or weblogic."
     pattern: "^(?!weblogic$|administrator$)[a-zA-Z][a-zA-Z0-9_-]{7,127}$"
     default: "wls_user_1"
     minLength: 8
     maxLength: 128
     required: true
 
-  wls_admin_password_id_1:
+  wls_secondary_admin_password_id:
     visible:
       and:
         - ${orm_create_mode}
         - ${configure_secure_mode}
     type: "oci:kms:secret:id"
     title: "Validated Secret for WebLogic Server Admin Password"
-    description: "The secret that contains the administration password of the second administrator in the WebLogic Server domain. Use a WebLogic Administrator password that starts with a letter, is between 8 and 30 characters long, contains at least one number, and, optionally, any number of the special characters ($ # _). For example, Ach1z0#d. To create secrets, see <a target=\"_blank\" href=\"https://docs.oracle.com/en/cloud/paas/weblogic-cloud/user/you-begin-oracle-weblogic-cloud.html#GUID-0517A019-4A89-40ED-A568-DD2193733F8B\">Create Secrets for Passwords</a>."
+    description: "The secret that contains the administration password of the secondary administrator in the WebLogic Server domain. Use a WebLogic Administrator password that starts with a letter, is between 8 and 30 characters long, contains at least one number, and, optionally, any number of the special characters ($ # _). For example, Ach1z0#d. To create secrets, see <a target=\"_blank\" href=\"https://docs.oracle.com/en/cloud/paas/weblogic-cloud/user/you-begin-oracle-weblogic-cloud.html#GUID-0517A019-4A89-40ED-A568-DD2193733F8B\">Create Secrets for Passwords</a>."
     required: true
     dependsOn:
       compartmentId: ${wls_admin_secret_compartment_id}

--- a/terraform/schema_14110.yaml
+++ b/terraform/schema_14110.yaml
@@ -39,6 +39,8 @@ groupings:
       - ${wls_admin_user}
       - ${wls_admin_secret_compartment_id}
       - ${wls_admin_password_id}
+      - ${wls_admin_user_1}
+      - ${wls_admin_password_id_1}
       - ${keystore_password_id}
       - ${root_ca_id}
       - ${wls_14c_jdk_version}
@@ -867,6 +869,32 @@ variables:
     title: "Throttle the thread pool"
     description: "Shared Capacity For Work Managers"
     required: true
+
+  wls_admin_user_1:
+    visible:
+      and:
+        - ${orm_create_mode}
+        - ${configure_secure_mode}
+    type: string
+    title: "WebLogic Server Admin User Name"
+    description: "The name of the second administrator in the WebLogic Server domain. The value should be between 8 and 128 characters long and alphanumeric, and can contain underscore (_) and hyphen(-) special characters, and should not be system, admin, administrator, or weblogic."
+    pattern: "^(?!weblogic$|administrator$)[a-zA-Z][a-zA-Z0-9_-]{7,127}$"
+    default: "wls_user_1"
+    minLength: 8
+    maxLength: 128
+    required: true
+
+  wls_admin_password_id_1:
+    visible:
+      and:
+        - ${orm_create_mode}
+        - ${configure_secure_mode}
+    type: "oci:kms:secret:id"
+    title: "Validated Secret for WebLogic Server Admin Password"
+    description: "The secret that contains the administration password of the second administrator in the WebLogic Server domain. Use a WebLogic Administrator password that starts with a letter, is between 8 and 30 characters long, contains at least one number, and, optionally, any number of the special characters ($ # _). For example, Ach1z0#d. To create secrets, see <a target=\"_blank\" href=\"https://docs.oracle.com/en/cloud/paas/weblogic-cloud/user/you-begin-oracle-weblogic-cloud.html#GUID-0517A019-4A89-40ED-A568-DD2193733F8B\">Create Secrets for Passwords</a>."
+    required: true
+    dependsOn:
+      compartmentId: ${wls_admin_secret_compartment_id}
 
   # WLS Network Configuration
   wls_vcn_name:

--- a/terraform/weblogic_variables.tf
+++ b/terraform/weblogic_variables.tf
@@ -233,3 +233,22 @@ variable "thread_pool_limit" {
   description = "Shared Capacity For Work Managers"
   default     = 65536
 }
+
+variable "wls_admin_user_1" {
+  type        = string
+  description = "Name of second WebLogic administration user"
+  default     = "wls_user_1"
+  validation {
+    condition     = replace(var.wls_admin_user_1, "/^[a-zA-Z][a-zA-Z0-9_-]{7,127}/", "0") == "0" && !contains(["system", "admin", "administrator", "weblogic"], var.wls_admin_user_1)
+    error_message = "WLSC-ERROR: The value for wls_admin_user_1 should be between 8 and 128 characters long and alphanumeric, and can contain underscore (_) and hyphen(-) special characters, and should not be system, admin, administrator, or weblogic."
+  }
+}
+
+variable "wls_admin_password_id_1" {
+  type        = string
+  description = "The OCID of the vault secret with the password for second WebLogic administration user"
+  validation {
+    condition     = length(regexall("^ocid1.vaultsecret.", var.wls_admin_password_id_1)) > 0
+    error_message = "WLSC-ERROR: The value for wls_admin_password_id_1 should start with \"ocid1.vaultsecret.\"."
+  }
+}

--- a/terraform/weblogic_variables.tf
+++ b/terraform/weblogic_variables.tf
@@ -27,10 +27,10 @@ variable "wls_node_count_limit" {
 variable "wls_admin_user" {
   type        = string
   description = "Name of WebLogic administration user"
-  default     = "wls_user"
+  default     = "weblogic"
   validation {
-    condition     = replace(var.wls_admin_user, "/^[a-zA-Z][a-zA-Z0-9_-]{7,127}/", "0") == "0" && !contains(["system", "admin", "administrator", "weblogic"], var.wls_admin_user)
-    error_message = "WLSC-ERROR: The value for wls_admin_user should be between 8 and 128 characters long and alphanumeric, and can contain underscore (_) and hyphen(-) special characters, and should not be system, admin, administrator, or weblogic."
+    condition     = replace(var.wls_admin_user, "/^[a-zA-Z][a-zA-Z0-9_-]{7,127}/", "0") == "0"
+    error_message = "WLSC-ERROR: The value for wls_admin_user should be between 8 and 128 characters long and alphanumeric, and can contain underscore (_) and hyphen(-) special characters."
   }
 }
 
@@ -234,21 +234,28 @@ variable "thread_pool_limit" {
   default     = 65536
 }
 
-variable "wls_admin_user_1" {
+variable "wls_primary_admin_user" {
   type        = string
-  description = "Name of second WebLogic administration user"
-  default     = "wls_user_1"
+  description = "Name of primary WebLogic administration user"
+  default     = "wls_user"
   validation {
-    condition     = replace(var.wls_admin_user_1, "/^[a-zA-Z][a-zA-Z0-9_-]{7,127}/", "0") == "0" && !contains(["system", "admin", "administrator", "weblogic"], var.wls_admin_user_1)
-    error_message = "WLSC-ERROR: The value for wls_admin_user_1 should be between 8 and 128 characters long and alphanumeric, and can contain underscore (_) and hyphen(-) special characters, and should not be system, admin, administrator, or weblogic."
+    condition     = replace(var.wls_primary_admin_user, "/^[a-zA-Z][a-zA-Z0-9_-]{7,127}/", "0") == "0" && !contains(["system", "admin", "administrator", "weblogic"], var.wls_primary_admin_user)
+    error_message = "WLSC-ERROR: The value for wls_primary_admin_user should be between 8 and 128 characters long and alphanumeric, and can contain underscore (_) and hyphen(-) special characters, and should not be system, admin, administrator, or weblogic."
   }
 }
 
-variable "wls_admin_password_id_1" {
+variable "wls_secondary_admin_user" {
   type        = string
-  description = "The OCID of the vault secret with the password for second WebLogic administration user"
+  description = "Name of secondary WebLogic administration user"
+  default     = "wls_user_1"
   validation {
-    condition     = length(regexall("^ocid1.vaultsecret.", var.wls_admin_password_id_1)) > 0
-    error_message = "WLSC-ERROR: The value for wls_admin_password_id_1 should start with \"ocid1.vaultsecret.\"."
+    condition     = replace(var.wls_secondary_admin_user, "/^[a-zA-Z][a-zA-Z0-9_-]{7,127}/", "0") == "0" && !contains(["system", "admin", "administrator", "weblogic"], var.wls_secondary_admin_user)
+    error_message = "WLSC-ERROR: The value for wls_secondary_admin_user should be between 8 and 128 characters long and alphanumeric, and can contain underscore (_) and hyphen(-) special characters, and should not be system, admin, administrator, or weblogic."
   }
+}
+
+variable "wls_secondary_admin_password_id" {
+  type        = string
+  description = "The OCID of the vault secret with the password for secondary WebLogic administration user"
+  default     = ""
 }


### PR DESCRIPTION
**Testing**

1. Additional admin user added in the UI with the default username as 'wls_user_1'.
   <img width="970" alt="Screenshot 2024-03-01 at 4 13 06 PM" src="https://github.com/oracle-quickstart/oci-weblogic-server/assets/148204723/c5018d33-1523-4e07-8fea-410a370fd5de">
2. Usernames 'weblogic' and 'administrator' are blocked in UI, while 'weblogic1' works fine.
     <img width="970" alt="Screenshot 2024-03-01 at 4 16 15 PM" src="https://github.com/oracle-quickstart/oci-weblogic-server/assets/148204723/eae6e89b-5189-4f83-82f0-a12ee768a2c7"> <img width="970" alt="Screenshot 2024-03-01 at 4 16 35 PM" src="https://github.com/oracle-quickstart/oci-weblogic-server/assets/148204723/926204d3-33d0-4af8-a327-aa6ca3047418"> <img width="970" alt="Screenshot 2024-03-01 at 4 18 30 PM" src="https://github.com/oracle-quickstart/oci-weblogic-server/assets/148204723/dd1f31c6-955e-492d-96fb-b1ecc3a9a2e3">
3. Username 'weblogic' is blocked in terraform.
     <img width="970" alt="Screenshot 2024-03-01 at 7 46 56 PM" src="https://github.com/oracle-quickstart/oci-weblogic-server/assets/148204723/ce5b04cf-beee-44d7-9b35-0ee03114d98f"> <img width="1414" alt="Screenshot 2024-03-01 at 7 48 31 PM" src="https://github.com/oracle-quickstart/oci-weblogic-server/assets/148204723/79bc2626-b619-4e18-9be0-8dd3fd9b00f3">

