### PR TITLE
JCS-14392 -  Issue with volume attachments on scale-out

### DIFF
--- a/terraform/modules/compute/wls_compute/wls_compute.tf
+++ b/terraform/modules/compute/wls_compute/wls_compute.tf
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, Oracle and/or its affiliates.
+# Copyright (c) 2023, 2024, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 module "compute-keygen" {

--- a/terraform/modules/compute/wls_compute/wls_compute.tf
+++ b/terraform/modules/compute/wls_compute/wls_compute.tf
@@ -9,7 +9,7 @@ module "wls-instances" {
 
   source = "../instance"
 
-  instance_params = { for x in range(var.num_vm_instances) : "${local.host_label}-${x}" => {
+  instance_params = { for x in range(var.num_vm_instances) : "${local.host_label}-${format("%02d", x)}" => {
 
     availability_domain = var.use_regional_subnet ? local.ad_names[(x + local.admin_ad_index) % length(local.ad_names)] : var.availability_domain
 

--- a/terraform/modules/compute/wls_compute/wls_volume.tf
+++ b/terraform/modules/compute/wls_compute/wls_volume.tf
@@ -3,7 +3,7 @@
 
 module "middleware-volume" {
   source = "../volume"
-  bv_params = { for x in range(var.num_vm_instances) : "${var.resource_name_prefix}-mw-block-${x}" => {
+  bv_params = { for x in range(var.num_vm_instances) : "${var.resource_name_prefix}-mw-block-${format("%02d", x)}" => {
     ad             = var.use_regional_subnet ? local.ad_names[(x + local.admin_ad_index) % length(local.ad_names)] : var.availability_domain
     compartment_id = var.compartment_id
     display_name   = "${var.resource_name_prefix}-mw-block-${x}"
@@ -18,7 +18,7 @@ module "middleware-volume" {
 
 module "data-volume" {
   source = "../volume"
-  bv_params = { for x in range(var.num_vm_instances) : "${var.resource_name_prefix}-data-block-${x}" => {
+  bv_params = { for x in range(var.num_vm_instances) : "${var.resource_name_prefix}-data-block-${format("%02d", x)}" => {
     ad             = var.use_regional_subnet ? local.ad_names[(x + local.admin_ad_index) % length(local.ad_names)] : var.availability_domain
     compartment_id = var.compartment_id
     display_name   = "${var.resource_name_prefix}-data-block-${x}"
@@ -35,7 +35,7 @@ module "middleware_volume_attach" {
 
   bv_params = { empty = { ad = "", compartment_id = "", display_name = "", bv_size = 0, defined_tags = { def = "" }, freeform_tags = { free = "" } } }
 
-  bv_attach_params = { for x in range(var.num_vm_instances * var.num_volumes) : "${var.resource_name_prefix}-block-volume-attach-${x}" => {
+  bv_attach_params = { for x in range(var.num_vm_instances * var.num_volumes) : "${var.resource_name_prefix}-block-volume-attach-${format("%02d", x)}" => {
     display_name    = "${var.resource_name_prefix}-block-volume-attach-${x}"
     attachment_type = "iscsi"
     instance_id     = module.wls-instances.instance_ids[x / var.num_volumes]
@@ -49,7 +49,7 @@ module "data_volume_attach" {
 
   bv_params = { empty = { ad = "", compartment_id = "", display_name = "", bv_size = 0, defined_tags = { def = "" }, freeform_tags = { free = "" } } }
 
-  bv_attach_params = { for x in range(var.num_vm_instances * var.num_volumes) : "${var.resource_name_prefix}-block-volume-attach-${x}" => {
+  bv_attach_params = { for x in range(var.num_vm_instances * var.num_volumes) : "${var.resource_name_prefix}-block-volume-attach-${format("%02d", x)}" => {
     display_name    = "${var.resource_name_prefix}-block-volume-attach-${x}"
     attachment_type = "iscsi"
     instance_id     = module.wls-instances.instance_ids[x / var.num_volumes]

--- a/terraform/modules/compute/wls_compute/wls_volume.tf
+++ b/terraform/modules/compute/wls_compute/wls_volume.tf
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, Oracle and/or its affiliates.
+# Copyright (c) 2023, 2024, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 module "middleware-volume" {


### PR DESCRIPTION
- Make the keys of the maps of compute and volumes resources to have 2 digits at the end, to conserve the iteration order, which is lexicographical, to prevent volume attachments from being reassigned to other instances because of the iteration order in the list of compute instances

Tests:
- Created a non-JRF stack with new VCN, and two nodes
- Scaled up the stack to 4 nodes, verified the apply job completed successfully and that all servers were added.
- Scaled up the stack to 10 nodes, and verified the same points above
- Scaled up the stack to 11 nodes, and made the same verifications above, and verified that the existing block volume attachments and block volumes where not affected 
- Scaled up the stack to 20 nodes, and made the same verifications above
- Scaled up the stack to 30 nodes, and made the same verifications above
- Scaled down the stack to 10 nodes. Verified that only the artifacts 29 to 10 are deleted, and the rest of the servers are still running