### PR TITLE
JCS-14388 - Implementation: Remove the secrule from managed server NSG which opens all ports for wls subnet cidr.

### DIFF
--- a/terraform/modules/network/vcn-config/nsg_security_rule.tf
+++ b/terraform/modules/network/vcn-config/nsg_security_rule.tf
@@ -61,7 +61,7 @@ resource "oci_core_network_security_group_security_rule" "wls_ingress_security_r
 }
 
 resource "oci_core_network_security_group_security_rule" "wls_ingress_internal_security_rule" {
-
+  count                     = var.configure_secure_mode ? 0 : 1
   network_security_group_id = element(var.nsg_ids["managed_nsg_id"], 0)
   direction                 = "INGRESS"
   protocol                  = "6"
@@ -69,6 +69,24 @@ resource "oci_core_network_security_group_security_rule" "wls_ingress_internal_s
   source      = var.wls_subnet_cidr
   source_type = "CIDR_BLOCK"
   stateless   = false
+}
+
+resource "oci_core_network_security_group_security_rule" "wls_ingress_spm_internal_security_rule" {
+  count                     = var.configure_secure_mode ? 1 : 0
+  network_security_group_id = element(var.nsg_ids["managed_nsg_id"], 0)
+  direction                 = "INGRESS"
+  protocol                  = "6"
+
+  source      = var.wls_subnet_cidr
+  source_type = "CIDR_BLOCK"
+  stateless   = false
+
+  tcp_options {
+    destination_port_range {
+      min = var.administration_port
+      max = var.administration_port
+    }
+  }
 }
 
 resource "oci_core_network_security_group_security_rule" "wls_ingress_app_ms_security_rule" {

--- a/terraform/modules/network/vcn-config/nsg_security_rule.tf
+++ b/terraform/modules/network/vcn-config/nsg_security_rule.tf
@@ -71,7 +71,7 @@ resource "oci_core_network_security_group_security_rule" "wls_ingress_internal_s
   stateless   = false
 }
 
-resource "oci_core_network_security_group_security_rule" "wls_ingress_spm_internal_security_rule" {
+resource "oci_core_network_security_group_security_rule" "wls_ingress_internal_security_rule_secure_mode" {
   count                     = var.configure_secure_mode ? 1 : 0
   network_security_group_id = element(var.nsg_ids["managed_nsg_id"], 0)
   direction                 = "INGRESS"


### PR DESCRIPTION
Apply job succeeded for 2 node provisioning

![Screenshot 2024-05-08 at 5 45 17 PM](https://github.com/oracle-quickstart/oci-weblogic-server/assets/146092665/3ba06c7b-ed4d-4959-94c3-04156daded5a)

![Scr](https://github.com/oracle-quickstart/oci-weblogic-server/assets/146092665/4c386072-f635-4718-a301-89667a20a3f7)

Modified the secrule from managed server NSG which now opens for administration port 9002 instead of all ports for wls subnet cidr in case of secured production mode


![image](https://github.com/oracle-quickstart/oci-weblogic-server/assets/146092665/d12346f7-b89f-4aeb-ab28-e51bb6981a7d)
