### PR TITLE
Disable JRF for secured production mode

### DIFF
--- a/terraform/modules/validators/validators.tf
+++ b/terraform/modules/validators/validators.tf
@@ -79,4 +79,8 @@ locals {
   invalid_administration_ports     = var.configure_secure_mode && var.administration_port == var.ms_administration_port
   invalid_administration_ports_msg = "WLSC-ERROR: The value for administration_port=[${var.administration_port}] and ms_administration_port=[${var.ms_administration_port}] cannot be same."
   validate_administration_ports    = local.invalid_administration_ports ? local.validators_msg_map[local.invalid_administration_ports_msg] : null
+
+  invalid_jrf_12c_secure_mode      = var.configure_secure_mode && (var.is_oci_db || var.is_atp_db || trimspace(var.oci_db_connection_string) != "")
+  invalid_jrf_12c_secure_mode_msg  = "WLSC-ERROR: JRF domain is not supported for FMW 12c version in secured production mode."
+  validate_jrf_12c_secure_mode     = local.invalid_jrf_12c_secure_mode ? local.validators_msg_map[local.invalid_jrf_12c_secure_mode_msg] : ""
 }

--- a/terraform/schema.yaml
+++ b/terraform/schema.yaml
@@ -1653,7 +1653,11 @@ variables:
     default: true
 
   add_JRF:
-    visible: ${orm_create_mode}
+    visible:
+      and:
+        - ${orm_create_mode}
+        - not:
+           - ${configure_secure_mode}
     type: boolean
     default: false
     title: "Provision with JRF"


### PR DESCRIPTION
https://jira.oraclecorp.com/jira/browse/JCS-14477

Testing
========
**Show that the ORM UI in 12.2.1.4 does not show the JRF option when secured production mode is enabled.**
<img width="676" alt="image" src="https://github.com/oracle-quickstart/oci-weblogic-server/assets/106961326/04d0e1d1-84bb-41d4-8ad4-2d3fa1a2149c">
<img width="512" alt="image" src="https://github.com/oracle-quickstart/oci-weblogic-server/assets/106961326/98424c5c-dda8-4216-91d6-2ce000534067">


**Execute the CLI with variable contents that would indicate JRF usage and secured production mode enabled and show that validation error is raised.**

**With ATP-DB variables:**
<img width="1069" alt="image" src="https://github.com/oracle-quickstart/oci-weblogic-server/assets/106961326/cfc74f26-0e1a-4015-a503-bf8e78fb7c96">

**With OCI-DB variables:**
<img width="1081" alt="image" src="https://github.com/oracle-quickstart/oci-weblogic-server/assets/106961326/8605fe61-50df-42e5-b797-96cc650af6bb">

