### PR TITLE
Open port 9072 for weblogic subnet in managed server NSG in secure mode

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -63,6 +63,7 @@ module "network-vcn-config" {
   wls_extern_ssl_admin_port  = var.wls_extern_ssl_admin_port
   wls_extern_admin_port      = var.wls_extern_admin_port
   wls_expose_admin_port      = var.wls_expose_admin_port
+  wls_admin_ssl_port         = var.wls_admin_ssl_port
   wls_admin_port_source_cidr = var.wls_admin_port_source_cidr
   wls_ms_content_port        = local.add_load_balancer ? (var.is_idcs_selected ? var.idcs_cloudgate_port : (var.configure_secure_mode ? var.wls_ms_extern_ssl_port : var.wls_ms_extern_port)) : var.wls_ms_extern_ssl_port
   assign_backend_public_ip   = local.assign_weblogic_public_ip

--- a/terraform/modules/network/vcn-config/nsg_security_rule.tf
+++ b/terraform/modules/network/vcn-config/nsg_security_rule.tf
@@ -89,6 +89,24 @@ resource "oci_core_network_security_group_security_rule" "wls_ingress_internal_s
   }
 }
 
+resource "oci_core_network_security_group_security_rule" "wls_ingress_internal_ssl_security_rule_secure_mode" {
+  count                     = var.configure_secure_mode ? 1 : 0
+  network_security_group_id = element(var.nsg_ids["managed_nsg_id"], 0)
+  direction                 = "INGRESS"
+  protocol                  = "6"
+
+  source      = var.wls_subnet_cidr
+  source_type = "CIDR_BLOCK"
+  stateless   = false
+
+  tcp_options {
+    destination_port_range {
+      min = var.wls_admin_ssl_port
+      max = var.wls_admin_ssl_port
+    }
+  }
+}
+
 resource "oci_core_network_security_group_security_rule" "wls_ingress_app_ms_security_rule" {
   count                     = length(var.wls_ms_source_cidrs) > 0 ? length(var.wls_ms_source_cidrs) : 0
   network_security_group_id = element(var.nsg_ids["managed_nsg_id"], 0)

--- a/terraform/modules/network/vcn-config/variables.tf
+++ b/terraform/modules/network/vcn-config/variables.tf
@@ -215,3 +215,8 @@ variable "administration_port" {
   type        = number
   description = "The domain-wide administration port to configure a secure WebLogic domain"
 }
+
+variable "wls_admin_ssl_port" {
+  type        = number
+  description = "The administration server port for T3s protocol"
+}

--- a/terraform/weblogic_variables.tf
+++ b/terraform/weblogic_variables.tf
@@ -106,6 +106,7 @@ variable "wls_admin_ssl_port" {
     error_message = "WLSC-ERROR: The value for wls_admin_ssl_port should be greater than 0."
   }
 }
+
 variable "wls_expose_admin_port" {
   type        = bool
   description = "[WARNING] Selecting this option will expose the console to the internet if the default 0.0.0.0/0 CIDR is used. You should change the CIDR range below to allow access to a trusted IP range."


### PR DESCRIPTION
This MR is to open port 9072 for weblogic subnet CIDR in managed server NSG in secure mode