### PR TITLE
 Add validation for node count in secure mode

### DIFF
--- a/terraform/modules/validators/validators.tf
+++ b/terraform/modules/validators/validators.tf
@@ -84,6 +84,8 @@ locals {
   invalid_jrf_12c_secure_mode_msg  = "WLSC-ERROR: JRF domain is not supported for FMW 12c version in secured production mode."
   validate_jrf_12c_secure_mode     = local.invalid_jrf_12c_secure_mode ? local.validators_msg_map[local.invalid_jrf_12c_secure_mode_msg] : ""
 
+  # Provisioning in secure mode is not supported with more than 3 nodes at a time.
+  # Scaleout in secure mode is supported by adding only 1 node at a time.
   invalid_vm_count_provisioning_secure_mode      = var.configure_secure_mode && var.provisioned_node_count == 0 && (var.num_vm_instances > 3)
   invalid_vm_count_scaleout_secure_mode          = var.configure_secure_mode && var.provisioned_node_count > 0 && (var.num_vm_instances - var.provisioned_node_count > 1)
   invalid_vm_count_provisioning_secure_mode_msg  = "WLSC-ERROR: The value for wls_node_count=[${var.num_vm_instances}] is not valid. Provisioning in secured production mode is not supported with more than 4 nodes at a time. So, the value for wls_node_count in this case cannot exceed 3."

--- a/terraform/modules/validators/validators.tf
+++ b/terraform/modules/validators/validators.tf
@@ -83,4 +83,11 @@ locals {
   invalid_jrf_12c_secure_mode      = var.configure_secure_mode && (var.is_oci_db || var.is_atp_db || trimspace(var.oci_db_connection_string) != "")
   invalid_jrf_12c_secure_mode_msg  = "WLSC-ERROR: JRF domain is not supported for FMW 12c version in secured production mode."
   validate_jrf_12c_secure_mode     = local.invalid_jrf_12c_secure_mode ? local.validators_msg_map[local.invalid_jrf_12c_secure_mode_msg] : ""
+
+  invalid_vm_count_provisioning_secure_mode      = var.configure_secure_mode && var.provisioned_node_count == 0 && (var.num_vm_instances > 3)
+  invalid_vm_count_scaleout_secure_mode          = var.configure_secure_mode && var.provisioned_node_count > 0 && (var.num_vm_instances - var.provisioned_node_count > 1)
+  invalid_vm_count_provisioning_secure_mode_msg  = "WLSC-ERROR: The value for wls_node_count=[${var.num_vm_instances}] is not valid. The permissible value during provisioning cannot exceed the value 3."
+  invalid_vm_count_scaleout_secure_mode_msg      = "WLSC-ERROR: The value for wls_node_count=[${var.num_vm_instances}] is not valid. The permissible value during scaleout cannot exceed the value [${var.provisioned_node_count + 1}] ."
+  validate_vm_count_provisioning_secure_mode     = local.invalid_vm_count_provisioning_secure_mode ? local.validators_msg_map[local.invalid_vm_count_provisioning_secure_mode_msg] : null
+  validate_vm_count_scaleout_secure_mode         = local.invalid_vm_count_scaleout_secure_mode ? local.validators_msg_map[local.invalid_vm_count_scaleout_secure_mode_msg] : null
 }

--- a/terraform/modules/validators/validators.tf
+++ b/terraform/modules/validators/validators.tf
@@ -86,8 +86,8 @@ locals {
 
   invalid_vm_count_provisioning_secure_mode      = var.configure_secure_mode && var.provisioned_node_count == 0 && (var.num_vm_instances > 3)
   invalid_vm_count_scaleout_secure_mode          = var.configure_secure_mode && var.provisioned_node_count > 0 && (var.num_vm_instances - var.provisioned_node_count > 1)
-  invalid_vm_count_provisioning_secure_mode_msg  = "WLSC-ERROR: The value for wls_node_count=[${var.num_vm_instances}] is not valid. The permissible value during provisioning cannot exceed the value 3."
-  invalid_vm_count_scaleout_secure_mode_msg      = "WLSC-ERROR: The value for wls_node_count=[${var.num_vm_instances}] is not valid. The permissible value during scaleout cannot exceed the value [${var.provisioned_node_count + 1}] ."
+  invalid_vm_count_provisioning_secure_mode_msg  = "WLSC-ERROR: The value for wls_node_count=[${var.num_vm_instances}] is not valid. Provisioning in secured production mode is not supported with more than 4 nodes at a time. So, the value for wls_node_count in this case cannot exceed 3."
+  invalid_vm_count_scaleout_secure_mode_msg      = "WLSC-ERROR: The value for wls_node_count=[${var.num_vm_instances}] is not valid. Scaleout in secured production mode is supported by adding only 1 node at a time. So, the value for wls_node_count in this case cannot exceed [${var.provisioned_node_count + 1}] ."
   validate_vm_count_provisioning_secure_mode     = local.invalid_vm_count_provisioning_secure_mode ? local.validators_msg_map[local.invalid_vm_count_provisioning_secure_mode_msg] : null
   validate_vm_count_scaleout_secure_mode         = local.invalid_vm_count_scaleout_secure_mode ? local.validators_msg_map[local.invalid_vm_count_scaleout_secure_mode_msg] : null
 }


### PR DESCRIPTION
This PR is to add validation for node count in secure mode:
1. Provisioning is not supported with more than 3 nodes at a time.
2. Scaleout is supported by adding only 1 node at a time.

Testing
======
**Provisioning with more than 3 nodes(multi-node) in secure mode:**
<img width="1500" alt="image" src="https://github.com/oracle-quickstart/oci-weblogic-server/assets/106961326/f2f63204-e492-424d-b086-00f1837cd06e">

**When existing node count is 5 and scaleout is requested for 7 nodes:**
<img width="1490" alt="image" src="https://github.com/oracle-quickstart/oci-weblogic-server/assets/106961326/85ae1c05-7c1d-4506-b4ca-cc67ecb68bf4">




 