### PR TITLE
Open node manager port in managed server NSG

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -67,6 +67,7 @@ module "network-vcn-config" {
   wls_admin_port_source_cidr = var.wls_admin_port_source_cidr
   wls_ms_content_port        = local.add_load_balancer ? (var.is_idcs_selected ? var.idcs_cloudgate_port : (var.configure_secure_mode ? var.wls_ms_extern_ssl_port : var.wls_ms_extern_port)) : var.wls_ms_extern_ssl_port
   assign_backend_public_ip   = local.assign_weblogic_public_ip
+  wls_nm_port                = var.wls_nm_port
   configure_secure_mode      = var.configure_secure_mode
   administration_port        = var.administration_port
 

--- a/terraform/modules/network/vcn-config/nsg_security_rule.tf
+++ b/terraform/modules/network/vcn-config/nsg_security_rule.tf
@@ -71,6 +71,23 @@ resource "oci_core_network_security_group_security_rule" "wls_ingress_internal_s
   stateless   = false
 }
 
+resource "oci_core_network_security_group_security_rule" "wls_ingress_nm_security_rule" {
+  network_security_group_id = element(var.nsg_ids["managed_nsg_id"], 0)
+  direction                 = "INGRESS"
+  protocol                  = "6"
+
+  source      = var.wls_subnet_cidr
+  source_type = "CIDR_BLOCK"
+  stateless   = false
+
+  tcp_options {
+    destination_port_range {
+      min = var.wls_nm_port
+      max = var.wls_nm_port
+    }
+  }
+}
+
 resource "oci_core_network_security_group_security_rule" "wls_ingress_internal_security_rule_secure_mode" {
   count                     = var.configure_secure_mode ? 1 : 0
   network_security_group_id = element(var.nsg_ids["managed_nsg_id"], 0)

--- a/terraform/modules/network/vcn-config/variables.tf
+++ b/terraform/modules/network/vcn-config/variables.tf
@@ -206,6 +206,11 @@ variable "add_existing_mount_target" {
   default     = false
 }
 
+variable "wls_nm_port" {
+  type        = number
+  description = "The listen port number for the node manager process on all compute instances"
+}
+
 variable "configure_secure_mode" {
   type        = bool
   description = "Set to true to configure a secure WebLogic domain"


### PR DESCRIPTION
Open node manager port in managed server NSG

<img width="1189" alt="image" src="https://github.com/oracle-quickstart/oci-weblogic-server/assets/106961326/e34aab1e-8e78-433a-a567-21835c14f0ed">

**Tested 5 node provisioning in secure mode & non-secure mode. updateDomain.sh shows no error in provisioning logs**
<img width="1173" alt="image" src="https://github.com/oracle-quickstart/oci-weblogic-server/assets/106961326/14409ae9-1e89-4213-ba7a-f931220982db">

<img width="1187" alt="image" src="https://github.com/oracle-quickstart/oci-weblogic-server/assets/106961326/ecc227a3-9319-4c93-84b0-1f6c6e4ffe81">

