### PR TITLE
Add new flag for autoscaling alarm state defaulted to true

### DIFF
--- a/terraform/autoscaling_variables.tf
+++ b/terraform/autoscaling_variables.tf
@@ -1,5 +1,11 @@
-# Copyright (c) 2023, Oracle and/or its affiliates.
+# Copyright (c) 2023,2024, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+variable "enable_autoscaling_alarms" {
+  type        = bool
+  description = "Indicating autoscaling alarms state"
+  default     = true
+}
 
 variable "use_autoscaling" {
   type        = bool

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -562,6 +562,8 @@ module "observability-autoscaling" {
   create_policies     = var.create_policies
   use_oci_logging     = var.use_oci_logging
 
+  enable_autoscaling_alarms = var.enable_autoscaling_alarms
+
   tags = {
     defined_tags  = local.defined_tags
     freeform_tags = local.free_form_tags

--- a/terraform/modules/observability/autoscaling/monitoring_alarms.tf
+++ b/terraform/modules/observability/autoscaling/monitoring_alarms.tf
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, Oracle and/or its affiliates.
+# Copyright (c) 2023,2024, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 resource "oci_monitoring_alarm" "wlsc_scaleout_monitoring_alarm" {
@@ -8,7 +8,7 @@ resource "oci_monitoring_alarm" "wlsc_scaleout_monitoring_alarm" {
   body                  = local.alarm_body[format("%s ScaleOut", var.wls_metric)]
   destinations          = formatlist(oci_ons_notification_topic.wlsc_scaleout_notification_topic.id)
   display_name          = format("%s_scaleout_monitoring_alarm", var.service_prefix_name)
-  is_enabled            = var.create_policies
+  is_enabled            = var.enable_autoscaling_alarms
   metric_compartment_id = var.metric_compartment_id
   namespace             = var.alarm_namspace
   query                 = local.alarm_mql_map[format("%s ScaleOut", var.wls_metric)]
@@ -34,7 +34,7 @@ resource "oci_monitoring_alarm" "wlsc_scalein_monitoring_alarm" {
   body                  = local.alarm_body[format("%s ScaleOut", var.wls_metric)]
   destinations          = formatlist(oci_ons_notification_topic.wlsc_scalein_notification_topic.id)
   display_name          = format("%s_scalein_monitoring_alarm", var.service_prefix_name)
-  is_enabled            = var.create_policies
+  is_enabled            = var.enable_autoscaling_alarms
   metric_compartment_id = var.metric_compartment_id
   namespace             = var.alarm_namspace
   query                 = local.alarm_mql_map[format("%s ScaleIn", var.wls_metric)]

--- a/terraform/modules/observability/autoscaling/variables.tf
+++ b/terraform/modules/observability/autoscaling/variables.tf
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, Oracle and/or its affiliates.
+# Copyright (c) 2023,2024, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 variable "compartment_id" {
@@ -129,4 +129,10 @@ variable "use_oci_logging" {
   type        = bool
   description = "Enable logging service integration for WebLogic instances"
   default     = false
+}
+
+variable "enable_autoscaling_alarms" {
+  type        = bool
+  description = "Indicating autoscaling alarms state"
+  default     = true
 }

--- a/terraform/schema.yaml
+++ b/terraform/schema.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, Oracle and/or its affiliates.
+# Copyright (c) 2023,2024, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 title: Oracle WebLogic Server for Oracle Cloud Infrastructure
@@ -216,6 +216,7 @@ groupings:
       - ${wls_expose_admin_port}
       - ${mount_path}
       - ${alarm_severity}
+      - ${enable_autoscaling_alarms}
       - ${ocir_region}
       - ${ucm_instance_image_id}
       - ${ucm_listing_id}

--- a/terraform/schema_14110.yaml
+++ b/terraform/schema_14110.yaml
@@ -224,6 +224,7 @@ groupings:
       - ${oci_db_connection_string}
       - ${use_oci_db_connection_string}
       - ${alarm_severity}
+      - ${enable_autoscaling_alarms}
       - ${ocir_region}
       - ${ucm_instance_image_id}
       - ${ucm_listing_id}


### PR DESCRIPTION
The monitoring alarm is being created as enabled only when the option "Create OCI policies" checkbox is selected. The problem seems to be in monitoring_alarms.tf line 11 because the flag "is_enabled" is associated directly to var.create_policies which doesn't make sense. This PR is to add a new variable independent to var.create_policies so when customer clear the "Create OCI policies" checkbox the alarms created for autoscaling remain enabled.

This option is intentionally hidden to the customer as we don't have a use case for customers to create autoscaling with disabled alarms and these are defaulted to true. The variables are configured in case of advanced customers who may want to customize the stack can easily override those variables.

Testing with OCI Checkbox enabled:

-     Verify new variable is not shown in ORM UI.
**12.2.1.4**
![345111004-d5f0e922-7f4f-4300-8d04-ca16f03dd73c](https://github.com/oracle-quickstart/oci-weblogic-server/assets/44181317/490e30e1-a844-4ad8-9418-a98f7f7d16e5)

**14.1.1**
<img width="772" alt="image" src="https://github.com/oracle-quickstart/oci-weblogic-server/assets/106961326/f14cf051-00c5-4f8b-a06c-c3493b129e3d">

Usually undefined variables are shown at the bottom, this image is evidence that new variable is hidden from customer and default value (true) is used.

-     Verify that provisioning succeed with OCI policy checkbox enabled and when autosacling is enabled alarms are enabled after provisioning
![345111695-9cd6395d-ccc1-439e-8ab7-31f498a31e0d](https://github.com/oracle-quickstart/oci-weblogic-server/assets/44181317/d43eef16-d2cf-438b-979b-30b0841d8f86)
![345111870-864383e0-e987-416b-a2c0-44251b024c1f](https://github.com/oracle-quickstart/oci-weblogic-server/assets/44181317/779cc653-aa9a-452a-9d04-38199d29730b)

-     Verify that provisioning succeed with OCI policy checkbox disabled and when autosacling is enabled alarms are enabled after provisioning
![345112076-4af137ca-707c-4f82-b977-7d73c0389cd9-1](https://github.com/oracle-quickstart/oci-weblogic-server/assets/44181317/a97ff757-5af2-4453-b2e0-56e4fbcaed34)
![345112160-0c45d6ef-8037-49b9-8cd0-6886ac7dd9f5](https://github.com/oracle-quickstart/oci-weblogic-server/assets/44181317/b9915eb2-979f-4cfb-a4a3-4654f52ad5f3)

