### PR TITLE
JCS-14499 - Use the latest IDCS appgateway 23.4.44

### DIFF
--- a/terraform/modules/compute/wls_compute/idcs_variables.tf
+++ b/terraform/modules/compute/wls_compute/idcs_variables.tf
@@ -74,19 +74,19 @@ variable "idcs_cloudgate_config_file" {
 variable "idcs_cloudgate_docker_image_tar" {
   type        = string
   description = "Path of the binary file with the container image to run IDCS cloudgate container in the WebLogic VM"
-  default     = "/u01/zips/jcs/app_gateway_docker/21.2.2/app-gateway-docker-image.tar.gz"
+  default     = "/u01/zips/jcs/app_gateway_docker/23.4.44/app-gateway-docker-image.tar.gz"
 }
 
 variable "idcs_cloudgate_docker_image_version" {
   type        = string
   description = "Version of the container image to run IDCS cloudgate container in the WebLogic VM"
-  default     = "21.2.2-2105050509"
+  default     = "23.4.44-2310291619"
 }
 
 variable "idcs_cloudgate_docker_image_name" {
   type        = string
   description = "Name of the container image to run IDCS cloudgate container in the WebLogic VM"
-  default     = "idcs/idcs-appgateway"
+  default     = "idcs-appgateway-docker"
 }
 
 variable "lbip" {


### PR DESCRIPTION
Update IDCS appgateway to 23.4.44-2310291619. This container image version in 23.4.44 changed to idcs-appgateway-docker.
Tested multi-node 12.2.1.4 and 14.1.1.0 in secured production mode and non-secured production mode by accessing IDCS sample app.