### PR TITLE
JCS-14565 - Default is_rms_private_endpoint_required to true

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -123,8 +123,8 @@ variable "tf_script_version" {
 
 variable "is_rms_private_endpoint_required" {
   type        = bool
-  description = "Set resource manager private endpoint. Default value is true"
-  default     = true
+  description = "Set resource manager private endpoint. Default value is false"
+  default     = false
 }
 
 variable "add_rms_private_endpoint" {


### PR DESCRIPTION
Set is_rms_private_endpoint_required to true by so CLI users do not have to set this to false. Since a true value is only relevant to ORM execution the default of true was causing issues for CLI users. Verified that default value of false in terraform while ORM UI YAMLs have a default true does not cause any regressions.