### PR TITLE
Provide an option to put all the Compute instances in the same AD

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -631,6 +631,7 @@ module "compute" {
   wls_server_startup_args   = var.wls_server_startup_args
   wls_existing_vcn_id       = var.wls_existing_vcn_id
   create_policies           = var.create_policies
+  place_all_compute_in_same_ad = var.place_all_compute_in_same_ad
 
   # Secured Production Mode
   configure_secure_mode              = var.configure_secure_mode

--- a/terraform/modules/compute/wls_compute/variables.tf
+++ b/terraform/modules/compute/wls_compute/variables.tf
@@ -26,6 +26,12 @@ variable "availability_domain" {
   description = "The label of the availability domain where the compute will be created"
 }
 
+variable "place_all_compute_in_same_ad" {
+  type        = bool
+  description = "Set to true if you want to use the same Availability Domain (AD) as the admin compute instance for all Compute Instances."
+  default     = false
+}
+
 variable "instance_image_id" {
   type        = string
   description = "The OCID of the image used to create the compute instance"

--- a/terraform/modules/compute/wls_compute/variables.tf
+++ b/terraform/modules/compute/wls_compute/variables.tf
@@ -28,7 +28,7 @@ variable "availability_domain" {
 
 variable "place_all_compute_in_same_ad" {
   type        = bool
-  description = "Set to true if you want to use the same Availability Domain (AD) as the admin compute instance for all Compute Instances."
+  description = "Set to true if you want to use the same Availability Domain for all Compute instances as the WebLogic Administration Server's Compute instance. Otherwise, instances will be distributed across Availability Domains."
   default     = false
 }
 

--- a/terraform/modules/compute/wls_compute/wls_compute.tf
+++ b/terraform/modules/compute/wls_compute/wls_compute.tf
@@ -11,7 +11,7 @@ module "wls-instances" {
 
   instance_params = { for x in range(var.num_vm_instances) : "${local.host_label}-${format("%02d", x)}" => {
 
-    availability_domain = var.use_regional_subnet ? local.ad_names[(x + local.admin_ad_index) % length(local.ad_names)] : var.availability_domain
+    availability_domain = var.use_regional_subnet ? (var.place_all_compute_in_same_ad ? var.availability_domain : local.ad_names[(x + local.admin_ad_index) % length(local.ad_names)] ) : var.availability_domain
 
     compartment_id = var.compartment_id
     display_name   = "${local.host_label}-${x}"

--- a/terraform/modules/compute/wls_compute/wls_volume.tf
+++ b/terraform/modules/compute/wls_compute/wls_volume.tf
@@ -4,7 +4,7 @@
 module "middleware-volume" {
   source = "../volume"
   bv_params = { for x in range(var.num_vm_instances) : "${var.resource_name_prefix}-mw-block-${format("%02d", x)}" => {
-    ad             = var.use_regional_subnet ? local.ad_names[(x + local.admin_ad_index) % length(local.ad_names)] : var.availability_domain
+    ad             = var.use_regional_subnet ? (var.place_all_compute_in_same_ad ? var.availability_domain : local.ad_names[(x + local.admin_ad_index) % length(local.ad_names)]) : var.availability_domain
     compartment_id = var.compartment_id
     display_name   = "${var.resource_name_prefix}-mw-block-${x}"
     bv_size        = var.volume_size
@@ -19,7 +19,7 @@ module "middleware-volume" {
 module "data-volume" {
   source = "../volume"
   bv_params = { for x in range(var.num_vm_instances) : "${var.resource_name_prefix}-data-block-${format("%02d", x)}" => {
-    ad             = var.use_regional_subnet ? local.ad_names[(x + local.admin_ad_index) % length(local.ad_names)] : var.availability_domain
+    ad             = var.use_regional_subnet ? (var.place_all_compute_in_same_ad ? var.availability_domain : local.ad_names[(x + local.admin_ad_index) % length(local.ad_names)]) : var.availability_domain
     compartment_id = var.compartment_id
     display_name   = "${var.resource_name_prefix}-data-block-${x}"
     bv_size        = var.volume_size

--- a/terraform/network_variables.tf
+++ b/terraform/network_variables.tf
@@ -75,6 +75,12 @@ variable "wls_availability_domain_name" {
   default     = ""
 }
 
+variable "place_all_compute_in_same_ad" {
+  type        = bool
+  description = "Set to true if you want to use the same Availability Domain (AD) as the admin compute instance for all Compute Instances."
+  default     = false
+}
+
 variable "assign_weblogic_public_ip" {
   type        = bool
   description = "Set to true if the WebLogic compute instances will be created in a public subnet and should have a public IP"

--- a/terraform/network_variables.tf
+++ b/terraform/network_variables.tf
@@ -77,7 +77,7 @@ variable "wls_availability_domain_name" {
 
 variable "place_all_compute_in_same_ad" {
   type        = bool
-  description = "Set to true if you want to use the same Availability Domain (AD) as the admin compute instance for all Compute Instances."
+  description = "Set to true if you want to use the same Availability Domain for all Compute instances as the WebLogic Administration Server's Compute instance. Otherwise, instances will be distributed across Availability Domains."
   default     = false
 }
 

--- a/terraform/schema.yaml
+++ b/terraform/schema.yaml
@@ -466,9 +466,6 @@ variables:
         - eq:
             - ${subnet_span}
             - "Regional Subnet"
-        - gt:
-            - ${wls_node_count}
-            - 1
     type: boolean
     required: true
     default: false

--- a/terraform/schema.yaml
+++ b/terraform/schema.yaml
@@ -96,6 +96,7 @@ groupings:
       #- ${image_mode}
       #- ${terms_and_conditions}
       - ${wls_availability_domain_name}
+      - ${place_all_compute_in_same_ad}
       - ${wls_subnet_id}
       - ${wls_subnet_cidr}
       - ${existing_admin_server_nsg_id}
@@ -457,6 +458,19 @@ variables:
               - eq:
                 - ${subnet_span}
                 - "Regional Subnet"
+
+  place_all_compute_in_same_ad:
+    visible:
+      and:
+        - ${orm_create_mode}
+        - eq:
+            - ${subnet_span}
+            - "Regional Subnet"
+    type: boolean
+    required: true
+    default: false
+    title: "Use Same Availability Domain for all Compute Instances"
+    description: "Use the same Availability Domain for all Compute instances as that of the WebLogic Administration Server's Compute instance."
 
   wls_node_count:
     type: integer

--- a/terraform/schema.yaml
+++ b/terraform/schema.yaml
@@ -466,11 +466,14 @@ variables:
         - eq:
             - ${subnet_span}
             - "Regional Subnet"
+        - gt:
+            - ${wls_node_count}
+            - 1
     type: boolean
     required: true
     default: false
     title: "Use Same Availability Domain for all Compute Instances"
-    description: "Use the same Availability Domain for all Compute instances as that of the WebLogic Administration Server's Compute instance."
+    description: "Use the same Availability Domain for all Compute instances as that of the WebLogic Administration Server's Compute instance. If this option is not selected, the compute instances will be distributed across Availability Domains."
 
   wls_node_count:
     type: integer

--- a/terraform/schema_14110.yaml
+++ b/terraform/schema_14110.yaml
@@ -464,9 +464,6 @@ variables:
         - eq:
             - ${subnet_span}
             - "Regional Subnet"
-        - gt:
-            - ${wls_node_count}
-            - 1
     type: boolean
     required: true
     default: false

--- a/terraform/schema_14110.yaml
+++ b/terraform/schema_14110.yaml
@@ -69,6 +69,7 @@ groupings:
       #- ${image_mode}
       #- ${terms_and_conditions}
       - ${wls_availability_domain_name}
+      - ${place_all_compute_in_same_ad}
       - ${wls_subnet_id}
       - ${wls_subnet_cidr}
       - ${existing_admin_server_nsg_id}
@@ -455,6 +456,19 @@ variables:
               - eq:
                 - ${subnet_span}
                 - "Regional Subnet"
+
+  place_all_compute_in_same_ad:
+    visible:
+      and:
+        - ${orm_create_mode}
+        - eq:
+            - ${subnet_span}
+            - "Regional Subnet"
+    type: boolean
+    required: true
+    default: false
+    title: "Use Same Availability Domain for all Compute Instances"
+    description: "Use the same Availability Domain for all Compute instances as that of the WebLogic Administration Server's Compute instance."
 
   wls_node_count:
     type: integer

--- a/terraform/schema_14110.yaml
+++ b/terraform/schema_14110.yaml
@@ -464,11 +464,14 @@ variables:
         - eq:
             - ${subnet_span}
             - "Regional Subnet"
+        - gt:
+            - ${wls_node_count}
+            - 1
     type: boolean
     required: true
     default: false
     title: "Use Same Availability Domain for all Compute Instances"
-    description: "Use the same Availability Domain for all Compute instances as that of the WebLogic Administration Server's Compute instance."
+    description: "Use the same Availability Domain for all Compute instances as that of the WebLogic Administration Server's Compute instance. If this option is not selected, the compute instances will be distributed across Availability Domains."
 
   wls_node_count:
     type: integer


### PR DESCRIPTION
In the UI show that there is an option to put all the Compute instances in the same AD.
Show that the option is not selected by default. 

check box : **Use Same Availability Domain for all Compute Instances**
![Screenshot 2024-12-05 at 10 30 13 PM](https://github.com/user-attachments/assets/bd32f71f-81f4-4713-b710-e56a15b49e57)



Show that if the option is selected in the UI that the Compute instances are all in the same AD.
![Screenshot 2024-12-02 at 5 02 04 PM](https://github.com/user-attachments/assets/bcd71402-9276-4af2-b511-72762d55da01)

IDCS instance with this option selected has the IDCS sample app added correctly. 
![Screenshot 2024-12-02 at 5 57 42 PM](https://github.com/user-attachments/assets/5fdaa374-974f-4b71-9cea-0d8ea564920d)

Show that the backends for the load balancer are set up correctly.
![Screenshot 2024-12-02 at 6 00 48 PM](https://github.com/user-attachments/assets/614763d4-caa0-4865-b59a-48ae3f9ed5f0)

Perform and scale out and show that the additional instance is added in the same AD.
![Screenshot 2024-12-02 at 5 50 36 PM](https://github.com/user-attachments/assets/9f2fdf86-e354-4fe7-b75b-e4b7c85368bc)

Show that there are no issues with cloning.
![Screenshot 2024-11-29 at 11 34 23 PM](https://github.com/user-attachments/assets/188798e9-e9fa-40b7-bf41-c75fa72ed739)
![Screenshot 2024-11-29 at 11 43 21 PM](https://github.com/user-attachments/assets/d089337a-bdaf-43ae-ba63-4f9c7d6eedb0)
![Screenshot 2024-11-29 at 11 48 23 PM](https://github.com/user-attachments/assets/8c6938be-3fd8-4286-80ca-8f9f3b460ade)

Show that there are no issues with autoscaling.

`Apply complete! Resources: 65 added, 0 changed, 0 destroyed.

Outputs:
autoscaling_function_application_id = "ocid1.fnapp.oc1.iad.aaaaaaaaazznl7uei34qyfl4sxxvvyelkmd5ufm6dw6zcw7bjpcioygt7e3q"
autoscaling_scalein_monitoring_alarm_id = "ocid1.alarm.oc1.iad.aaaaaaaajhkebpkshceyjvv6wcp64o5idne6clphnpqmtbjak5z5awuexqlq"
autoscaling_scaleout_monitoring_alarm_id = "ocid1.alarm.oc1.iad.aaaaaaaatrkvqzy3chqsipyjfckky7z6yl7xbt27t7iqp5s442a6n4nrkpna"
bastion_instance_id = "ocid1.instance.oc1.iad.anuwcljsncovviycmzj4xxabupcceaqv37c4jcx3uzjldozfhge3hpg2z34q"
bastion_instance_public_ip = "158.101.110.29"
fss_system_id = ""
fusion_middleware_control_console = ""
is_vcn_peered = false
jdk_version = "JDK 8"
listing_version = "21.3.1-210716051200"
load_balancer_id = "ocid1.loadbalancer.oc1.iad.aaaaaaaalicohve6qymbik76b62h3x6aksdd356yy2vwjdxtw3wh5rwe67ca"
load_balancer_ip = "150.136.31.236"
mount_target_id = ""
provisioning_status = "Asynchronous provisioning is enabled. Connect to each compute instance and confirm that the file /u01/data/domains/adauto_domain/provCompletedMarker exists. Details are found in the file /u01/logs/provisioning.log."
resource_identifier_value = tolist([
  "adauto-b57a7325",
  "ccbhat",
])
rms_private_endpoint_id = ""
sample_application = "https://150.136.31.236/sample-app"
sample_application_protected_by_idcs = ""
ssh_command = ""
ssh_command_with_dynamic_port_forwarding = ""
virtual_cloud_network_cidr = "10.0.0.0/16"
virtual_cloud_network_id = "ocid1.vcn.oc1.iad.amaaaaaancovviyaisnuupkdcpktyck2ygy4q2et4slpostpkrrhp7medutq"
webLogic_server_domain_configuration = "Production Mode"
weblogic_agent_configuration_id = ""
weblogic_instances = "[\""{ Instance Id:ocid1.instance.oc1.iad.anuwcljsncovviychbkobah2k27m4efwq6wjt3h2v356xuckue3xdzajc7bq, Instance name:adauto-wls-0, Availability Domain:PEKi:US-ASHBURN-AD-2, Instance Shape:VM.Standard.E4.Flex, Private IP:10.0.2.211, Public IP: }\"",\""{ Instance Id:ocid1.instance.oc1.iad.anuwcljsncovviycif6fifncrtlfebdykgvuadfam6jjz7rvatkj63mlqs3a, Instance name:adauto-wls-1, Availability Domain:PEKi:US-ASHBURN-AD-2, Instance Shape:VM.Standard.E4.Flex, Private IP:10.0.2.157, Public IP: }\""]"
weblogic_log_group_id = ""
weblogic_log_id = ""
weblogic_server_administration_console = "https://10.0.2.211:7002/console"
weblogic_version = "12.2.1.4 Enterprise Edition (Non JRF)" `

if the option is not selected in the UI that the Compute instances are still spread across ADs (regression test).
![Screenshot 2024-12-02 at 6 16 45 PM](https://github.com/user-attachments/assets/c6aafd3d-1688-45af-808c-ec16ca510cd7)