### PR TITLE
Fix for Load Balancer NSG not visible in edit stack when add existing NSG is selected

### DIFF
--- a/terraform/schema.yaml
+++ b/terraform/schema.yaml
@@ -1633,7 +1633,6 @@ variables:
   existing_lb_nsg_id:
     visible:
       and:
-        - ${orm_create_mode}
         - ${add_existing_nsg}
         - or:
             - ${add_load_balancer}

--- a/terraform/schema_14110.yaml
+++ b/terraform/schema_14110.yaml
@@ -1641,7 +1641,6 @@ variables:
   existing_lb_nsg_id:
     visible:
       and:
-        - ${orm_create_mode}
         - ${add_existing_nsg}
         - or:
             - ${add_load_balancer}

--- a/terraform/schema_14120.yaml
+++ b/terraform/schema_14120.yaml
@@ -1644,7 +1644,6 @@ variables:
   existing_lb_nsg_id:
     visible:
       and:
-        - ${orm_create_mode}
         - ${add_existing_nsg}
         - or:
             - ${add_load_balancer}


### PR DESCRIPTION
Issue: Load Balancer NSG not visible in edit stack when add existing NSG is selected.

Before:
=====
<img width="896" alt="image" src="https://github.com/user-attachments/assets/7873fda9-81bc-4bc2-ba19-4dea6b769bac" />


After:
===
<img width="920" alt="image" src="https://github.com/user-attachments/assets/4d70dbec-e97f-4011-aef9-a88c2b6a6e84" />
