### PR TITLE
Split policy statements in two due to OCI 50 statement policy limit

### DIFF
--- a/terraform/modules/policies/locals.tf
+++ b/terraform/modules/policies/locals.tf
@@ -129,7 +129,7 @@ locals {
   secure_mode_statement  = compact([local.secure_mode_statement1, local.secure_mode_statement2, local.secure_mode_statement3, local.secure_mode_statement4, local.secure_mode_statement5, local.secure_mode_secrets_policy_statement1, local.secure_mode_secrets_policy_statement2])
 
   #TODO: When other categories with more statements are added here, concat them with service_statements
-  policy_statements = concat(local.service_statements, local.cloning_policy_statement, local.plugin_policy_statement, local.autoscaling_statements, local.secure_mode_statement)
+  policy_statements = concat(local.service_statements, local.cloning_policy_statement, local.plugin_policy_statement, local.secure_mode_statement)
 
   reserved_ips_info = var.compartment_id == "" ? [{ id = var.resource_name_prefix }] : []
 

--- a/terraform/modules/policies/wlsc_policies.tf
+++ b/terraform/modules/policies/wlsc_policies.tf
@@ -15,3 +15,19 @@ resource "oci_identity_policy" "wlsc_oci_policy" {
   }
 }
 
+
+resource "oci_identity_policy" "wlsc_oci_policy_autoscaling" {
+
+  count = var.use_autoscaling?1:0
+
+  compartment_id = var.tenancy_id
+  description    = "Autoscaling Policies required for WLS on OCI"
+  name           = "${local.label_prefix}-oci-policy-autoscaling"
+  statements     = local.autoscaling_statements
+
+  defined_tags  = var.tags.defined_tags
+  freeform_tags = var.tags.freeform_tags
+  lifecycle {
+    ignore_changes = [defined_tags, freeform_tags]
+  }
+}


### PR DESCRIPTION
Split policy statements in two due to OCI 50 statement policy limit.