### PR TITLE
JCS-14708: Remove OSMS from WLS for OCI Stacks

### DIFF
--- a/terraform/modules/compute/instance/instance.tf
+++ b/terraform/modules/compute/instance/instance.tf
@@ -44,6 +44,11 @@ resource "oci_core_instance" "these" {
       desired_state = "ENABLED"
       name          = "Bastion"
     }
+    plugins_config {
+      #Required to remove OSMS
+      desired_state = "DISABLED"
+      name          = "OS Management Service Agent"
+    }
   }
 
   metadata = each.value.metadata


### PR DESCRIPTION
Ticket: [JCS-14708](https://jira.oraclecorp.com/jira/browse/JCS-14708)

Made changes in the `terraform/modules/compute/instance/instance.tf` to include a plugin configuration block, disabling the OS Management Service Agent plugin during WLS for OCI stack provisioning. Hence no need of script changes.

Testing:
Successfully tested the change with WLS for OCI stack provisioning on version 14.1.2.