### PR TITLE
Added changes for enhancement in OSMH policies.

### DIFF
--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -196,8 +196,8 @@ locals {
   select_existing_profile         = var.select_existing_profile
   create_profile                  = (local.enable_osmh && !local.select_existing_profile) ? true : false
   profile_ocid                    = local.select_existing_profile ? var.profile_ocid : ""
-  profile_compartment_id          = var.profile_compartment_id
-  profile_name                    = var.profile_name
+  profile_compartment_id          = var.profile_compartment_id == "" ? var.compartment_ocid : var.profile_compartment_id
+  profile_name                    = var.profile_name == "" ? format("%s_profile", local.service_name_prefix) : var.profile_name
 
   # Secured Production Mode
   preserve_boot_properties          = var.configure_secure_mode ? var.preserve_boot_properties : true

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -486,7 +486,7 @@ module "validators" {
   administration_port             = var.administration_port
   ms_administration_port          = var.ms_administration_port
 
-  profile_ocid = local.profile_ocid
+  profile_ocid            = local.profile_ocid
   select_existing_profile = local.select_existing_profile
 }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -239,6 +239,7 @@ module "policies" {
   apm_domain_compartment_id        = local.apm_domain_compartment_id
   use_autoscaling                  = var.use_autoscaling
   enable_osmh                      = var.enable_osmh
+  profile_compartment_id           = var.profile_compartment_id
   ocir_auth_token_id               = var.ocir_auth_token_id
   add_fss                          = var.add_fss
   add_load_balancer                = local.add_load_balancer

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -485,6 +485,9 @@ module "validators" {
   wls_secondary_admin_password_id = local.wls_secondary_admin_password_id
   administration_port             = var.administration_port
   ms_administration_port          = var.ms_administration_port
+
+  profile_ocid = local.profile_ocid
+  select_existing_profile = local.select_existing_profile
 }
 
 module "fss" {
@@ -594,7 +597,7 @@ module "observability-osmh"{
   source              = "./modules/observability/osmh"
   count               = local.create_profile ? 1 : 0
   tenancy_id          = var.tenancy_ocid
-  display_name        = var.profile_name
+  display_name        = local.profile_name
   compartment_id      = local.profile_compartment_id
 }
 

--- a/terraform/modules/observability/osmh/versions.tf
+++ b/terraform/modules/observability/osmh/versions.tf
@@ -1,0 +1,10 @@
+# Copyright (c) 2023, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+terraform {
+  required_providers {
+    oci = {
+      source = "oracle/oci"
+    }
+  }
+}

--- a/terraform/modules/policies/locals.tf
+++ b/terraform/modules/policies/locals.tf
@@ -54,7 +54,7 @@ locals {
 
   # Policies required for enabling the OSMH plugin
   osmh_policy_statement1 = var.enable_osmh? "Allow dynamic-group ${oci_identity_dynamic_group.wlsc_instance_principal_group.name} to manage osmh-family in compartment id ${var.compartment_id}" : ""
-  osmh_policy_statement2 = var.enable_osmh? "Allow dynamic-group ${oci_identity_dynamic_group.wlsc_instance_principal_group.name}  to manage osmh-family in compartment id  ${var.profile_compartment_id}" : ""
+  osmh_policy_statement2 = var.enable_osmh? "Allow dynamic-group ${oci_identity_dynamic_group.wlsc_instance_principal_group.name} to manage osmh-family in compartment id  ${var.profile_compartment_id}" : ""
   osmh_policy_statement3 = var.enable_osmh? "Allow dynamic-group ${oci_identity_dynamic_group.wlsc_instance_principal_group.name} to {OSMH_MANAGED_INSTANCE_ACCESS} in tenancy where request.principal.id = target.managed-instance.id" : ""
   osmh_policy_statement4 = var.enable_osmh? "Allow dynamic-group ${oci_identity_dynamic_group.wlsc_instance_principal_group.name} to {MGMT_AGENT_DEPLOY_PLUGIN_CREATE, MGMT_AGENT_INSPECT, MGMT_AGENT_READ} in compartment id ${var.compartment_id}" : ""
   osmh_policy_statement  = compact([local.osmh_policy_statement1, local.osmh_policy_statement2, local.osmh_policy_statement3, local.osmh_policy_statement4])

--- a/terraform/modules/policies/locals.tf
+++ b/terraform/modules/policies/locals.tf
@@ -54,7 +54,7 @@ locals {
 
   # Policies required for enabling the OSMH plugin
   osmh_policy_statement1 = var.enable_osmh? "Allow dynamic-group ${oci_identity_dynamic_group.wlsc_instance_principal_group.name} to manage osmh-family in compartment id ${var.compartment_id}" : ""
-  osmh_policy_statement2 = var.enable_osmh? "Allow dynamic-group ${oci_identity_dynamic_group.wlsc_instance_principal_group.name} to manage osmh-family in compartment id  ${var.profile_compartment_id}" : ""
+  osmh_policy_statement2 = var.enable_osmh? var.profile_compartment_id != var.compartment_id? "Allow dynamic-group ${oci_identity_dynamic_group.wlsc_instance_principal_group.name} to manage osmh-family in compartment id  ${var.profile_compartment_id}" : "" : ""
   osmh_policy_statement3 = var.enable_osmh? "Allow dynamic-group ${oci_identity_dynamic_group.wlsc_instance_principal_group.name} to {OSMH_MANAGED_INSTANCE_ACCESS} in tenancy where request.principal.id = target.managed-instance.id" : ""
   osmh_policy_statement4 = var.enable_osmh? "Allow dynamic-group ${oci_identity_dynamic_group.wlsc_instance_principal_group.name} to {MGMT_AGENT_DEPLOY_PLUGIN_CREATE, MGMT_AGENT_INSPECT, MGMT_AGENT_READ} in compartment id ${var.compartment_id}" : ""
   osmh_policy_statement  = compact([local.osmh_policy_statement1, local.osmh_policy_statement2, local.osmh_policy_statement3, local.osmh_policy_statement4])

--- a/terraform/modules/policies/locals.tf
+++ b/terraform/modules/policies/locals.tf
@@ -53,9 +53,12 @@ locals {
   plugin_policy_statement = compact([local.plugin_policy_statement1, local.plugin_policy_statement2])
 
   # Policies required for enabling the OSMH plugin
-  osmh_policy_statement1 = var.enable_osmh? "Allow dynamic-group ${oci_identity_dynamic_group.wlsc_instance_principal_group.name} to manage osmh-family in tenancy" : ""
-  osmh_policy_statement2 = var.enable_osmh? "Allow dynamic-group ${oci_identity_dynamic_group.wlsc_instance_principal_group.name} to {OSMH_MANAGED_INSTANCE_ACCESS} in tenancy where request.principal.id = target.managed-instance.id" : ""
-  osmh_policy_statement  = compact([local.osmh_policy_statement1, local.osmh_policy_statement2])
+  osmh_policy_statement1 = var.enable_osmh? "Allow dynamic-group ${oci_identity_dynamic_group.wlsc_instance_principal_group.name} to manage osmh-family in compartment id ${var.compartment_id}" : ""
+  osmh_policy_statement2 = var.enable_osmh? "Allow dynamic-group MyInstancesPrincipalGroup to manage osmh-family in compartment id  ${var.profile_compartment_id}" : ""
+  osmh_policy_statement3 = var.enable_osmh? "Allow dynamic-group ${oci_identity_dynamic_group.wlsc_instance_principal_group.name} to {OSMH_MANAGED_INSTANCE_ACCESS} in tenancy where request.principal.id = target.managed-instance.id" : ""
+  osmh_policy_statement4 = var.enable_osmh? "Allow dynamic-group ${oci_identity_dynamic_group.wlsc_instance_principal_group.name} to {MGMT_AGENT_DEPLOY_PLUGIN_CREATE, MGMT_AGENT_INSPECT, MGMT_AGENT_READ} in compartment id ${var.compartment_id}" : ""
+  osmh_policy_statement  = compact([local.osmh_policy_statement1, local.osmh_policy_statement2, local.osmh_policy_statement3, local.osmh_policy_statement4])
+
 
   #Policies for WLS instance principal dynamic group
   autoscaling_statement1 = var.use_autoscaling ? "Allow dynamic-group ${oci_identity_dynamic_group.wlsc_instance_principal_group.name} to use repos in tenancy" : ""

--- a/terraform/modules/policies/locals.tf
+++ b/terraform/modules/policies/locals.tf
@@ -54,7 +54,7 @@ locals {
 
   # Policies required for enabling the OSMH plugin
   osmh_policy_statement1 = var.enable_osmh? "Allow dynamic-group ${oci_identity_dynamic_group.wlsc_instance_principal_group.name} to manage osmh-family in compartment id ${var.compartment_id}" : ""
-  osmh_policy_statement2 = var.enable_osmh? "Allow dynamic-group MyInstancesPrincipalGroup to manage osmh-family in compartment id  ${var.profile_compartment_id}" : ""
+  osmh_policy_statement2 = var.enable_osmh? "Allow dynamic-group ${oci_identity_dynamic_group.wlsc_instance_principal_group.name}  to manage osmh-family in compartment id  ${var.profile_compartment_id}" : ""
   osmh_policy_statement3 = var.enable_osmh? "Allow dynamic-group ${oci_identity_dynamic_group.wlsc_instance_principal_group.name} to {OSMH_MANAGED_INSTANCE_ACCESS} in tenancy where request.principal.id = target.managed-instance.id" : ""
   osmh_policy_statement4 = var.enable_osmh? "Allow dynamic-group ${oci_identity_dynamic_group.wlsc_instance_principal_group.name} to {MGMT_AGENT_DEPLOY_PLUGIN_CREATE, MGMT_AGENT_INSPECT, MGMT_AGENT_READ} in compartment id ${var.compartment_id}" : ""
   osmh_policy_statement  = compact([local.osmh_policy_statement1, local.osmh_policy_statement2, local.osmh_policy_statement3, local.osmh_policy_statement4])

--- a/terraform/modules/policies/variables.tf
+++ b/terraform/modules/policies/variables.tf
@@ -224,7 +224,11 @@ variable "wls_secondary_admin_password_id" {
   description = "The OCID of the vault secret with the password for secondary WebLogic administration user"
 }
 variable "enable_osmh" {
-  type = bool
+  type        = bool
   description = "Indicating that OSMH is enabled"
+}
+variable "profile_compartment_id"{
+  type        = string
+  description = "The compartment Id to create the profile"
 }
   

--- a/terraform/modules/validators/validators.tf
+++ b/terraform/modules/validators/validators.tf
@@ -84,11 +84,7 @@ locals {
   invalid_jrf_12c_secure_mode      = var.configure_secure_mode && local.is12cVersion && (var.is_oci_db || var.is_atp_db || trimspace(var.oci_db_connection_string) != "")
   invalid_jrf_12c_secure_mode_msg  = "WLSC-ERROR: JRF domain is not supported for FMW 12c version in secured production mode."
   validate_jrf_12c_secure_mode     = local.invalid_jrf_12c_secure_mode ? local.validators_msg_map[local.invalid_jrf_12c_secure_mode_msg] : ""
-  
+
   missing_profile_id_msg = "WLSC-ERROR: The value for profile id is required if existing profile is used for OSMH"
-  validate_profile_id = (
-    var.select_existing_profile && var.profile_ocid == ""
-    ? local.validators_msg_map[local.missing_profile_id_msg]
-    : null
-  )
+  validate_profile_id    = (var.select_existing_profile && var.profile_ocid == "" ? local.validators_msg_map[local.missing_profile_id_msg] : null)
 }

--- a/terraform/modules/validators/validators.tf
+++ b/terraform/modules/validators/validators.tf
@@ -84,4 +84,11 @@ locals {
   invalid_jrf_12c_secure_mode      = var.configure_secure_mode && local.is12cVersion && (var.is_oci_db || var.is_atp_db || trimspace(var.oci_db_connection_string) != "")
   invalid_jrf_12c_secure_mode_msg  = "WLSC-ERROR: JRF domain is not supported for FMW 12c version in secured production mode."
   validate_jrf_12c_secure_mode     = local.invalid_jrf_12c_secure_mode ? local.validators_msg_map[local.invalid_jrf_12c_secure_mode_msg] : ""
+  
+  missing_profile_id_msg = "WLSC-ERROR: The value for profile id is required if existing profile is used for OSMH"
+  validate_profile_id = (
+    var.select_existing_profile && var.profile_ocid == ""
+    ? local.validators_msg_map[local.missing_profile_id_msg]
+    : null
+  )
 }

--- a/terraform/modules/validators/variables.tf
+++ b/terraform/modules/validators/variables.tf
@@ -564,3 +564,11 @@ variable "ms_administration_port" {
   type        = number
   description = "The administration port for managed servers to configure a secure WebLogic domain"
 }
+variable "select_existing_profile"{
+  type        = bool
+  description = "Set to true to use an existing profile"
+}
+variable "profile_ocid"{
+  type        = string
+  description = "The ocid of the profile used for OSMH registration."
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -143,8 +143,6 @@ variable "profile_name" {
   description = "The name specified by user for creating the profile"
   default     = ""
 }
-
-
 variable "profile_compartment_id"{
   type        = string
   description = "The compartment Id to create the profile"

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     oci = {
       source  = "oracle/oci"
-      version = "4.96.0"
+      version = "6.34.0"
     }
     random = {
       version = "~>3.4.3"


### PR DESCRIPTION
Tested with the following scenarios:

- From the OCI console for the policy enhancement
<img width="1175" alt="Screenshot 2025-05-21 at 1 42 12 PM" src="https://github.com/user-attachments/assets/9992f756-900a-476e-a9e5-20fea5480b5e" />
Here, the compartments of both the stack and profile are the same; hence, only one policy is created for OSMH, avoiding duplication.
This is the case where the compartments of the stack and profile are different; hence, two policies are created for accessing OSMH in both the stack and profile compartments.
<img width="1176" alt="Screenshot 2025-05-21 at 1 44 20 PM" src="https://github.com/user-attachments/assets/5a2f1fe2-3b13-4528-a35a-b469c4c2c8e8" />

Terraform CLI changes.
If a stack is created through the Terraform CLI with the default values, OSMH will be enabled by default, since select existing profile defaults to false, a new profile will be created. 
If one needs to select an Existing profile, set the value to true & provide the profile OCID. If the OCID is not provided validation error will be thrown.