### PR TITLE
Upgrade Terraform version to 1.5.x for WLS for OCI

### DIFF
--- a/terraform/modules/lb/loadbalancer/outputs.tf
+++ b/terraform/modules/lb/loadbalancer/outputs.tf
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, Oracle and/or its affiliates.
+# Copyright (c) 2023, 2025, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 output "wls_loadbalancer_id" {
@@ -7,6 +7,6 @@ output "wls_loadbalancer_id" {
 }
 
 output "wls_loadbalancer_ip_addresses" {
-  value       = oci_load_balancer_load_balancer.wls_loadbalancer.ip_addresses
+  value       = oci_load_balancer_load_balancer.wls_loadbalancer.ip_address_details[*].ip_address
   description = "The list of IP addresses of the load balancer"
 }

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -2,26 +2,26 @@
 # Licensed under the Universal Permissive License v1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 terraform {
-  required_version = ">= 1.1.2, < 1.2.0"
+  required_version = "~> 1.5.7"
   required_providers {
     oci = {
       source  = "oracle/oci"
-      version = "6.34.0"
+      version = "~> 7.18.0"
     }
     random = {
-      version = "~>3.4.3"
+      version = "~> 3.7.2"
     }
     template = {
-      version = "~>2.2.0"
+      version = "~> 2.2.0"
     }
     tls = {
-      version = "~>4.0.3"
+      version = "~> 4.1.0"
     }
     time = {
-      version = "~>0.9.0"
+      version = "~> 0.13.1"
     }
     null = {
-      version = "~>3.1.1"
+      version = "~> 3.2.4"
     }
   }
 }

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, Oracle and/or its affiliates.
+# Copyright (c) 2023, 2025, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 terraform {

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     oci = {
       source  = "oracle/oci"
-      version = "~> 7.18.0"
+      version = "~> 7.17.0"
     }
     random = {
       version = "~> 3.7.2"


### PR DESCRIPTION
Upgrade Terraform version to 1.5.x for WLS for OCI.

Testing done - Stack provisioning successful through ORM with Terraform version 1.5.7.

<img width="1906" height="1001" alt="Screenshot 2025-09-19 at 10 23 58 PM" src="https://github.com/user-attachments/assets/9d1229ea-77cf-4682-9af9-ce46201f00be" />
<img width="1906" height="1001" alt="Screenshot 2025-09-19 at 10 24 15 PM" src="https://github.com/user-attachments/assets/3dea1bfe-19b1-4819-8451-903b310375d6" />
<img width="1906" height="1001" alt="Screenshot 2025-09-19 at 10 25 12 PM" src="https://github.com/user-attachments/assets/ac78e03a-83a4-4812-9f62-daec64756592" />
