### PR TITLE
Support WLS 15.1.1.0

### DIFF
--- a/builds/build_orm_dev.sh
+++ b/builds/build_orm_dev.sh
@@ -16,7 +16,7 @@ help()
   echo
   echo "Arguments: build_orm_dev.sh -v|--version <12.2.1.4|14.1.1.0|14.1.2.0|15.1.1.0> -t|--scripts_version --all"
   echo "options:"
-  echo "-v, --version             WebLogic version. Supported values are 12.2.1.4,14.1.2.0, 15.1.1.0, or 14.1.1.0 Optional when --all option is provided"
+  echo "-v, --version             WebLogic version. Supported values are 12.2.1.4, 14.1.2.0, 15.1.1.0, or 14.1.1.0. Optional when --all option is provided"
   echo "-t, --scripts_version     VM scripts version"
   echo "--all                     All bundles"
   echo

--- a/builds/build_orm_dev.sh
+++ b/builds/build_orm_dev.sh
@@ -14,9 +14,9 @@ help()
 {
   echo "Build the Oracle Resource Manager (ORM) bundles for developers to deploy in Marketplace"
   echo
-  echo "Arguments: build_orm_dev.sh -v|--version <12.2.1.4|14.1.1.0|14.1.2.0> -t|--scripts_version --all"
+  echo "Arguments: build_orm_dev.sh -v|--version <12.2.1.4|14.1.1.0|14.1.2.0|15.1.1.0> -t|--scripts_version --all"
   echo "options:"
-  echo "-v, --version             WebLogic version. Supported values are 12.2.1.4,14.1.2.0 or 14.1.1.0 Optional when --all option is provided"
+  echo "-v, --version             WebLogic version. Supported values are 12.2.1.4,14.1.2.0, 15.1.1.0, or 14.1.1.0 Optional when --all option is provided"
   echo "-t, --scripts_version     VM scripts version"
   echo "--all                     All bundles"
   echo
@@ -73,7 +73,7 @@ validate()
     echo "WebLogic version is not provided"
     help
     exit 1
-  elif [ "${WLS_VERSION}" != "12.2.1.4" ] && [ "${WLS_VERSION}" != "14.1.2.0" ] && [ "${WLS_VERSION}" != "14.1.1.0" ]; then
+  elif [ "${WLS_VERSION}" != "12.2.1.4" ] && [ "${WLS_VERSION}" != "14.1.2.0" ] && [ "${WLS_VERSION}" != "15.1.1.0" ] && [ "${WLS_VERSION}" != "14.1.1.0" ]; then
     echo "Please provide valid WebLogic version"
     help
     exit 1
@@ -113,6 +113,13 @@ create_14120_bundle()
   replace_14120_variables
   (cd ${TMP_BUILD}; zip -r ${SCRIPT_DIR}/binaries/wlsoci-resource-manager-ee-14120.zip *; rm -Rf ${TMP_BUILD}/*)
 }
+create_15110_bundle()
+{
+  cp -Rf ${SCRIPT_DIR}/../terraform/modules ${SCRIPT_DIR}/../terraform/*.tf ${SCRIPT_DIR}/../terraform/schema_15110.yaml ${TMP_BUILD}
+  cp -f ${SCRIPT_DIR}/../terraform/orm/orm_provider.tf ${TMP_BUILD}/provider.tf
+  replace_15110_variables
+  (cd ${TMP_BUILD}; zip -r ${SCRIPT_DIR}/binaries/wlsoci-resource-manager-ee-15110.zip *; rm -Rf ${TMP_BUILD}/*)
+}
 
 #need to change it to false after RM UI fix
 replace_12214_variables()
@@ -137,16 +144,26 @@ replace_14120_variables()
   sed -i '/variable "use_marketplace_image" {/!b;n;n;n;cdefault = false' ${TMP_BUILD}/mp_variables.tf
   sed -i '/variable "tf_script_version" {/!b;n;n;n;cdefault = \"'"$SCRIPTS_VERSION"'\"' ${TMP_BUILD}/variables.tf
 }
+replace_15110_variables()
+{
+  sed -i '/variable "generate_dg_tag" {/!b;n;n;n;cdefault = false' ${TMP_BUILD}/variables.tf
+  sed -i '/variable "wls_version" {/!b;n;n;n;cdefault = \"15.1.1.0\"' ${TMP_BUILD}/weblogic_variables.tf
+  sed -i '/variable "use_marketplace_image" {/!b;n;n;n;cdefault = false' ${TMP_BUILD}/mp_variables.tf
+  sed -i '/variable "tf_script_version" {/!b;n;n;n;cdefault = \"'"$SCRIPTS_VERSION"'\"' ${TMP_BUILD}/variables.tf
+}
 
 if [ "${CREATE_ALL_BUNDLES}" == "true" ]; then
   create_12214_bundle
   create_14110_bundle
   create_14120_bundle
+  create_15110_bundle
 else
   if [ "${WLS_VERSION}" == "12.2.1.4" ]; then
       create_12214_bundle
   elif [ "${WLS_VERSION}" == "14.1.2.0" ]; then
       create_14120_bundle
+  elif [ "${WLS_VERSION}" == "15.1.1.0" ]; then
+      create_15110_bundle
   else
       create_14110_bundle
   fi

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -111,6 +111,7 @@ locals {
   local.jdk_labels,
   var.wls_version == "14.1.1.0" ? var.wls_14c_jdk_version :
   var.wls_version == "14.1.2.0" ? var.wls_14120_jdk_version :
+  var.wls_version == "15.1.1.0" ? var.wls_15110_jdk_version :
   var.wls_version == "11.1.1.7" ? "jdk7" : "jdk8"
 )
 

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, 2024, Oracle and/or its affiliates.
+# Copyright (c) 2023, 2025, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 locals {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, 2024, Oracle and/or its affiliates.
+# Copyright (c) 2023, 2025, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 ### Removing network validation script from provisioning flow temporarily.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -625,6 +625,7 @@ module "compute" {
   use_regional_subnet       = local.use_regional_subnet
   wls_14c_jdk_version       = var.wls_14c_jdk_version
   wls_14120_jdk_version     = var.wls_14120_jdk_version
+  wls_15110_jdk_version     = var.wls_15110_jdk_version
   wls_admin_user            = local.wls_admin_user
   wls_admin_password_id     = var.wls_admin_password_id
   wls_admin_server_name     = format("%s_adminserver", local.service_name_prefix)

--- a/terraform/modules/compute/wls_compute/wls_compute.tf
+++ b/terraform/modules/compute/wls_compute/wls_compute.tf
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, 2024, 2025, Oracle and/or its affiliates.
+# Copyright (c) 2023, 2025, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 module "compute-keygen" {

--- a/terraform/modules/compute/wls_compute/wls_compute.tf
+++ b/terraform/modules/compute/wls_compute/wls_compute.tf
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, 2024, Oracle and/or its affiliates.
+# Copyright (c) 2023, 2024, 2025, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 module "compute-keygen" {
@@ -67,7 +67,7 @@ module "wls-instances" {
       wls_edition                        = var.wls_edition
       is_bastion_instance_required       = var.is_bastion_instance_required
       create_policies                    = var.create_policies
-      enable_restful_management_services = var.wls_version == "14.1.2.0" ? true : false
+      enable_restful_management_services = contains(["14.1.2.0", "15.1.1.0"], var.wls_version)
       # Secured Production Mode
       configure_secure_mode              = var.configure_secure_mode
       preserve_boot_properties           = var.preserve_boot_properties
@@ -87,7 +87,7 @@ module "wls-instances" {
       wls_version          = var.wls_version
       wls_14c_jdk_version  = var.wls_14c_jdk_version
       fmiddleware_zip      = var.wls_version_to_fmw_map[var.wls_version]
-      jdk_zip              = var.wls_version == "14.1.1.0" ? var.wls_14c_to_jdk_map[var.wls_14c_jdk_version] :var.wls_version == "14.1.2.0" ? var.wls_14120_to_jdk_map[var.wls_14120_jdk_version] :var.wls_version_to_jdk_map[var.wls_version]
+      jdk_zip              = var.wls_version == "14.1.1.0" ? var.wls_14c_to_jdk_map[var.wls_14c_jdk_version] : var.wls_version == "14.1.2.0" ? var.wls_14120_to_jdk_map[var.wls_14120_jdk_version] : var.wls_version == "15.1.1.0" ? var.wls_15110_to_jdk_map[var.wls_15110_jdk_version] : var.wls_version_to_jdk_map[var.wls_version]
       vmscripts_path       = var.vmscripts_path
       log_level            = var.log_level
       mw_vol_mount_point   = lookup(var.volume_map[0], "volume_mount_point")

--- a/terraform/modules/compute/wls_compute/wls_variables.tf
+++ b/terraform/modules/compute/wls_compute/wls_variables.tf
@@ -209,7 +209,7 @@ variable "wls_version_to_fmw_map" {
     "12.2.1.4" = "/u01/zips/jcs/FMW/12.2.1.4.0/fmiddleware.zip"
     "14.1.1.0" = "/u01/zips/jcs/FMW/14.1.1.0.0/fmiddleware.zip"
     "14.1.2.0" = "/u01/zips/jcs/FMW/14.1.2.0.0/fmiddleware.zip"
-    "14.1.2.0" = "/u01/zips/jcs/FMW/15.1.1.0.0/fmiddleware.zip"
+    "15.1.1.0" = "/u01/zips/jcs/FMW/15.1.1.0.0/fmiddleware.zip"
   }
 }
 

--- a/terraform/modules/compute/wls_compute/wls_variables.tf
+++ b/terraform/modules/compute/wls_compute/wls_variables.tf
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, Oracle and/or its affiliates.
+# Copyright (c) 2023, 2025, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 variable "wls_edition" {
@@ -169,8 +169,8 @@ variable "wls_version" {
   type        = string
   description = "The WebLogic version to be installed in this instance. Accepted values are: 12.2.1.4, 14.1.1.0"
   validation {
-    condition     = contains(["12.2.1.4", "14.1.1.0", "14.1.2.0"], var.wls_version)
-    error_message = "WLSC-ERROR: WebLogic Versions 12.2.1.4 , 14.1.1.0 and 14.1.2.0 are the only versions supported."
+    condition     = contains(["12.2.1.4", "14.1.1.0", "14.1.2.0", "15.1.1.0"], var.wls_version)
+    error_message = "WLSC-ERROR: WebLogic Versions 12.2.1.4 , 14.1.1.0, 14.1.2.0, and 15.1.1.0 are the only versions supported."
   }
 }
 
@@ -191,6 +191,16 @@ variable "wls_14120_jdk_version" {
     error_message = "WLSC-ERROR: Only jdk17 and jdk21 are supported with WebLogic version 14.1.2.0."
   }
 }
+
+variable "wls_15110_jdk_version" {
+  type        = string
+  description = "JDK version to use when installing WebLogic 15.1.1.0. Ignored when WebLogic version is not 15. Allowed values: jdk17, jdk21"
+  validation {
+    condition     = var.wls_15110_jdk_version == "" || contains(["jdk17", "jdk21"], var.wls_15110_jdk_version)
+    error_message = "WLSC-ERROR: Only jdk17 and jdk21 are supported with WebLogic version 15.1.1.0."
+  }
+}
+
 variable "wls_version_to_fmw_map" {
   type        = map(string)
   description = "Defines the mapping between wls_version and corresponding FMW zip"
@@ -199,6 +209,7 @@ variable "wls_version_to_fmw_map" {
     "12.2.1.4" = "/u01/zips/jcs/FMW/12.2.1.4.0/fmiddleware.zip"
     "14.1.1.0" = "/u01/zips/jcs/FMW/14.1.1.0.0/fmiddleware.zip"
     "14.1.2.0" = "/u01/zips/jcs/FMW/14.1.2.0.0/fmiddleware.zip"
+    "14.1.2.0" = "/u01/zips/jcs/FMW/15.1.1.0.0/fmiddleware.zip"
   }
 }
 
@@ -228,6 +239,16 @@ variable "wls_14120_to_jdk_map"{
     "jdk21" = "/u01/zips/jcs/JDK21.0/jdk.zip"
   }   
 }
+
+variable "wls_15110_to_jdk_map"{
+  type        = map(string)
+  description = "Defines the mapping between jdk version and corresponding JDK zip."
+  default = {
+    "jdk17"  = "/u01/zips/jcs/JDK17.0/jdk.zip"
+    "jdk21" = "/u01/zips/jcs/JDK21.0/jdk.zip"
+  }
+}
+
 variable "wls_version_to_rcu_component_list_map" {
   type        = map(string)
   description = "Defines the mapping between wls_version version and corresponding RCU components."

--- a/terraform/modules/validators/validators.tf
+++ b/terraform/modules/validators/validators.tf
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, 2024, Oracle and/or its affiliates.
+# Copyright (c) 2023, 2024, 2025, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 locals {
@@ -14,6 +14,10 @@ locals {
 
   is14110Version               = var.wls_version == "14.1.1.0"
   invalid_14110_jrf            = local.is14110Version && (var.is_atp_db || var.is_oci_db || var.oci_db_connection_string != "")
+
+  is15110Version               = var.wls_version == "15.1.1.0"
+  invalid_15110_jrf            = local.is15110Version && (var.is_atp_db || var.is_oci_db || var.oci_db_connection_string != "")
+
   invalid_multiple_infra_dbs = ((var.is_oci_db || var.oci_db_connection_string != "") && var.is_atp_db)
   both_vcn_param             = local.has_existing_vcn && local.has_vcn_name
 
@@ -28,8 +32,11 @@ locals {
   multiple_infra_dbs_msg              = "WLSC-ERROR: Both OCI and ATP database parameters are provided. Only one infra database is required."
   validate_invalid_multiple_infra_dbs = local.invalid_multiple_infra_dbs ? local.validators_msg_map[local.multiple_infra_dbs_msg] : null
 
-   jrf_14110_msg      = "WLSC-ERROR: JRF domain is not supported for FMW 14.1.1.0 version"
-   validate_14c_jrf   = local.invalid_14110_jrf ? local.validators_msg_map[local.jrf_14110_msg] : ""
+  jrf_14110_msg      = "WLSC-ERROR: JRF domain is not supported for FMW 14.1.1.0 version"
+  validate_14c_jrf   = local.invalid_14110_jrf ? local.validators_msg_map[local.jrf_14110_msg] : ""
+
+  jrf_15110_msg      = "WLSC-ERROR: JRF domain is not supported for 15.1.1.0 version"
+  validate_14c_jrf   = local.invalid_15110_jrf ? local.validators_msg_map[local.jrf_15110_msg] : ""
 
   missing_dynamic_group_oci_logging_enabled_create_policies_unset  = "WLSC-ERROR: Dynamic Group id is required when enabling integration with OCI Logging Service with create policies unset "
   validate_dynamic_group_oci_logging_enabled_create_policies_unset = !var.create_policies && var.use_oci_logging && var.dynamic_group_id == "" ? local.validators_msg_map[local.missing_dynamic_group_oci_logging_enabled_create_policies_unset] : null

--- a/terraform/modules/validators/validators.tf
+++ b/terraform/modules/validators/validators.tf
@@ -36,7 +36,7 @@ locals {
   validate_14c_jrf   = local.invalid_14110_jrf ? local.validators_msg_map[local.jrf_14110_msg] : ""
 
   jrf_15110_msg      = "WLSC-ERROR: JRF domain is not supported for 15.1.1.0 version"
-  validate_14c_jrf   = local.invalid_15110_jrf ? local.validators_msg_map[local.jrf_15110_msg] : ""
+  validate_15110_jrf   = local.invalid_15110_jrf ? local.validators_msg_map[local.jrf_15110_msg] : ""
 
   missing_dynamic_group_oci_logging_enabled_create_policies_unset  = "WLSC-ERROR: Dynamic Group id is required when enabling integration with OCI Logging Service with create policies unset "
   validate_dynamic_group_oci_logging_enabled_create_policies_unset = !var.create_policies && var.use_oci_logging && var.dynamic_group_id == "" ? local.validators_msg_map[local.missing_dynamic_group_oci_logging_enabled_create_policies_unset] : null

--- a/terraform/modules/validators/validators.tf
+++ b/terraform/modules/validators/validators.tf
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, 2024, 2025, Oracle and/or its affiliates.
+# Copyright (c) 2023, 2025, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 locals {

--- a/terraform/modules/validators/variables.tf
+++ b/terraform/modules/validators/variables.tf
@@ -152,7 +152,7 @@ variable "lb_subnet_2_id" {
 
 variable "wls_version" {
   type        = string
-  description = "The WebLogic version to be installed for this stack. Accepted values are: 12.2.1.4, 14.1.1.0"
+  description = "The WebLogic version to be installed for this stack. Accepted values are: 12.2.1.4, 14.1.1.0, 14.1.2.0, 15.1.1.0"
   validation {
     condition     = contains(["12.2.1.4", "14.1.1.0","14.1.2.0", "15.1.1.0"], var.wls_version)
     error_message = "WLSC-ERROR: Allowed values for wls_version are 12.2.1.4, 14.1.1.0, 14.1.2.0, 15.1.1.0."

--- a/terraform/modules/validators/variables.tf
+++ b/terraform/modules/validators/variables.tf
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, Oracle and/or its affiliates.
+# Copyright (c) 2023, 2025, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 variable "compartment_id" {
@@ -154,8 +154,8 @@ variable "wls_version" {
   type        = string
   description = "The WebLogic version to be installed for this stack. Accepted values are: 12.2.1.4, 14.1.1.0"
   validation {
-    condition     = contains(["12.2.1.4", "14.1.1.0","14.1.2.0"], var.wls_version)
-    error_message = "WLSC-ERROR: Allowed values for wls_version are 12.2.1.4, 14.1.1.0, 14.1.2.0."
+    condition     = contains(["12.2.1.4", "14.1.1.0","14.1.2.0", "15.1.1.0"], var.wls_version)
+    error_message = "WLSC-ERROR: Allowed values for wls_version are 12.2.1.4, 14.1.1.0, 14.1.2.0, 15.1.1.0."
   }
 }
 

--- a/terraform/schema.yaml
+++ b/terraform/schema.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, 2024, 2025, Oracle and/or its affiliates.
+# Copyright (c) 2023, 2025, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 title: Oracle WebLogic Server for Oracle Cloud Infrastructure

--- a/terraform/schema_14110.yaml
+++ b/terraform/schema_14110.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, 2024, Oracle and/or its affiliates.
+# Copyright (c) 2023, 2024, 2025, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 title: Oracle WebLogic Server for Oracle Cloud Infrastructure
@@ -194,6 +194,7 @@ groupings:
       - ${wls_version}
       - ${log_level}
       - ${wls_14120_jdk_version}
+      - ${wls_15110_jdk_version}
       #- ${instance_image_id}
       - ${marketplace_source_images}
       - ${use_regional_subnet}
@@ -2291,4 +2292,5 @@ variables:
       - 12.2.1.4
       - 14.1.1.0
       - 14.1.2.0
+      - 15.1.1.0
     default: 12.2.1.4

--- a/terraform/schema_14110.yaml
+++ b/terraform/schema_14110.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, 2024, 2025, Oracle and/or its affiliates.
+# Copyright (c) 2023, 2025, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 title: Oracle WebLogic Server for Oracle Cloud Infrastructure

--- a/terraform/schema_14120.yaml
+++ b/terraform/schema_14120.yaml
@@ -47,7 +47,6 @@ groupings:
       - ${root_ca_id}
       - ${cert_compartment_id}
       - ${wls_14120_jdk_version}
-      - ${wls_15110_jdk_version}
       - ${preserve_boot_properties}
       - ${add_JRF}
       #Start of JRF fields
@@ -248,6 +247,7 @@ groupings:
       - ${generate_dg_tag}
       - ${wait_time_wls_vnc_dns_resolver}
       - ${wls_14c_jdk_version}
+      - ${wls_15110_jdk_version}
       - ${wls_admin_port_source_cidr}
       - ${wlsoci_vmscripts_zip_bundle_path}
       - ${tf_script_version}

--- a/terraform/schema_14120.yaml
+++ b/terraform/schema_14120.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, 2024, Oracle and/or its affiliates.
+# Copyright (c) 2023, 2024, 2025, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 title: Oracle WebLogic Server for Oracle Cloud Infrastructure
@@ -47,6 +47,7 @@ groupings:
       - ${root_ca_id}
       - ${cert_compartment_id}
       - ${wls_14120_jdk_version}
+      - ${wls_15110_jdk_version}
       - ${preserve_boot_properties}
       - ${add_JRF}
       #Start of JRF fields
@@ -2763,4 +2764,5 @@ variables:
       - 12.2.1.4
       - 14.1.1.0
       - 14.1.2.0
+      - 15.1.1.0
     default: 12.2.1.4

--- a/terraform/schema_14120.yaml
+++ b/terraform/schema_14120.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, 2024, 2025, Oracle and/or its affiliates.
+# Copyright (c) 2023, 2025, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 title: Oracle WebLogic Server for Oracle Cloud Infrastructure

--- a/terraform/schema_15110.yaml
+++ b/terraform/schema_15110.yaml
@@ -47,7 +47,7 @@ groupings:
       - ${root_ca_id}
       - ${cert_compartment_id}
       - ${preserve_boot_properties}
-      - ${wls_14c_jdk_version}
+      - ${wls_15110_jdk_version}
       - ${deploy_sample_app}
       - ${wls_server_startup_args}
       - ${thread_pool_limit}
@@ -193,8 +193,8 @@ groupings:
       - ${listing_resource_version}
       - ${wls_version}
       - ${log_level}
+      - ${wls_14c_jdk_version}
       - ${wls_14120_jdk_version}
-      - ${wls_15110_jdk_version}
       #- ${instance_image_id}
       - ${marketplace_source_images}
       - ${use_regional_subnet}

--- a/terraform/schema_15110.yaml
+++ b/terraform/schema_15110.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, 2024, 2025, Oracle and/or its affiliates.
+# Copyright (c) 2023, 2025, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 title: Oracle WebLogic Server for Oracle Cloud Infrastructure

--- a/terraform/schema_15110.yaml
+++ b/terraform/schema_15110.yaml
@@ -47,34 +47,7 @@ groupings:
       - ${root_ca_id}
       - ${cert_compartment_id}
       - ${preserve_boot_properties}
-      - ${add_JRF}
-      #Start of JRF fields
-      - ${db_strategy}
-      - ${atp_db_compartment_id}
-      - ${atp_db_id}
-      - ${atp_db_uses_private_endpoint}
-      - ${atp_db_network_compartment_id}
-      - ${atp_db_existing_vcn_id}
-      - ${atp_db_secret_compartment_id}
-      - ${atp_db_password_id}
-      - ${atp_db_level}
-      - ${use_oci_db_connection_string}
-      - ${oci_db_connection_string}
-      - ${oci_db_compartment_id}
-      - ${oci_db_dbsystem_id}
-      - ${oci_db_network_compartment_id}
-      - ${oci_db_existing_vcn_id}
-      - ${oci_db_dbhome_id}
-      - ${oci_db_dbhome_major_version}
-      - ${oci_db_database_id}
-      - ${oci_db_pdb_service_name}
-      - ${oci_db_user}
-      - ${oci_db_secret_compartment_id}
-      - ${oci_db_password_id}
-      - ${oci_db_port}
-      - ${db_existing_vcn_add_secrule}
-      - ${db_vcn_lpg_id}
-      #End of JRF fields
+      - ${wls_14c_jdk_version}
       - ${deploy_sample_app}
       - ${wls_server_startup_args}
       - ${thread_pool_limit}
@@ -102,7 +75,7 @@ groupings:
       - ${wls_subnet_cidr}
       - ${existing_admin_server_nsg_id}
       - ${existing_managed_server_nsg_id}
-
+      
   - title: "OS Management Hub Profile"
     variables:
       - ${select_existing_profile}
@@ -220,6 +193,8 @@ groupings:
       - ${listing_resource_version}
       - ${wls_version}
       - ${log_level}
+      - ${wls_14120_jdk_version}
+      - ${wls_15110_jdk_version}
       #- ${instance_image_id}
       - ${marketplace_source_images}
       - ${use_regional_subnet}
@@ -233,8 +208,33 @@ groupings:
       - ${wls_admin_ssl_port}
       - ${wls_ms_port}
       - ${wls_ms_ssl_port}
+      - ${add_JRF}
+      - ${oci_db_compartment_id}
+      - ${oci_db_network_compartment_id}
+      - ${oci_db_existing_vcn_id}
+      - ${db_existing_vcn_add_secrule}
+      - ${oci_db_dbsystem_id}
+      - ${oci_db_dbhome_id}
+      - ${oci_db_dbhome_major_version}
+      - ${oci_db_database_id}
+      - ${oci_db_pdb_service_name}
+      - ${oci_db_user}
+      - ${oci_db_secret_compartment_id}
+      - ${oci_db_password_id}
+      - ${oci_db_port}
+      - ${atp_db_compartment_id}
+      - ${atp_db_id}
+      - ${atp_db_uses_private_endpoint}
+      - ${atp_db_network_compartment_id}
+      - ${atp_db_existing_vcn_id}
+      - ${atp_db_secret_compartment_id}
+      - ${atp_db_password_id}
+      - ${atp_db_level}
+      - ${db_strategy}
       - ${wls_expose_admin_port}
       - ${mount_path}
+      - ${oci_db_connection_string}
+      - ${use_oci_db_connection_string}
       - ${alarm_severity}
       - ${enable_autoscaling_alarms}
       - ${ocir_region}
@@ -244,10 +244,8 @@ groupings:
       - ${image_mode}
       - ${terms_and_conditions}
       - ${generate_dg_tag}
+      - ${db_vcn_lpg_id}
       - ${wait_time_wls_vnc_dns_resolver}
-      - ${wls_14c_jdk_version}
-      - ${wls_14120_jdk_version}
-      - ${wls_15110_jdk_version}
       - ${wls_admin_port_source_cidr}
       - ${wlsoci_vmscripts_zip_bundle_path}
       - ${tf_script_version}
@@ -586,6 +584,17 @@ variables:
     dependsOn:
       compartmentId: ${wls_admin_secret_compartment_id}
 
+  wls_15110_jdk_version:
+    visible: ${orm_create_mode}
+    type: enum
+    title: "Java Development Kit version"
+    description: "Select the Java Development Kit (JDK) version"
+    enum:
+      - "jdk17"
+      - "jdk21"
+    required: true
+    default: "jdk17"
+
   configure_wls_ports:
     visible: ${orm_create_mode}
     type: boolean
@@ -861,7 +870,7 @@ variables:
     visible: ${orm_create_mode}
     type: boolean
     required: true
-    default: false
+    default: true
     title: "Enable Secured Production Mode"
     description: "Configure a secure domain"
 
@@ -1189,7 +1198,7 @@ variables:
     default: true
     title: "Use Resource Manager Private Endpoint"
     description: "Provision a resource manager private endpoint on a private subnet to check the provisioning status of the private resources. If this and bastion are not selected, you must check the status of domain creation on the compute instance using /u01/logs/provisioning.log file, and any failures during domain creation are reported."
-
+    
   add_rms_private_endpoint:
     visible:
       and:
@@ -1225,7 +1234,7 @@ variables:
     required: true
     title: "Resource Manager Private Endpoint"
     description: "Resource manager private endpoint for private access."
-    
+
   is_bastion_with_reserved_public_ip:
     visible:
       and:
@@ -1263,7 +1272,7 @@ variables:
             - ${create_new_vcn}
             - ${create_new_subnets}
         - and:
-             - or:
+            - or:
                 - ${create_new_vcn}
                 - ${create_new_subnets}
     type: string
@@ -1388,7 +1397,6 @@ variables:
     dependsOn:
       compartmentId: ${network_compartment_id}
       vcnId: ${wls_existing_vcn_id}
-
 
   # Load Balancer Configuration
   add_load_balancer:
@@ -1731,476 +1739,6 @@ variables:
     required: true
     default: true
 
-  add_JRF:
-    visible:
-      and:
-        - ${orm_create_mode}
-        - not:
-           - ${configure_secure_mode}
-    type: boolean
-    default: false
-    title: "Provision with JRF"
-    description: "Deploy the Java Required Files (JRF) components and create the JRF schemas on the selected database"
-
-  db_strategy:
-    visible:
-      and:
-        - ${orm_create_mode}
-        - ${add_JRF}
-    type: enum
-    title: "Database Strategy"
-    description: "Choose the database strategy for WebLogic Server"
-    enum:
-      - "Autonomous Transaction Processing Database"
-      - "Database System"
-    default: "Autonomous Transaction Processing Database"
-    required: true
-
-  use_oci_db_connection_string:
-    visible:
-      and:
-        - ${orm_create_mode}
-        - ${add_JRF}
-        - and:
-            - not:
-                - ${create_new_vcn}
-            - eq:
-                - ${db_strategy}
-                - "Database System"
-    type: boolean
-    title: "Use Database Connection String"
-    description: "Use database connection string to create a single instance datasource for JRF schemas. You cannot create an Active GridLink or a Multi Data Source using this database connection string. For the database connection string, see <a target=\"_blank\" href=\"https://docs.oracle.com/en/cloud/paas/weblogic-cloud/user/configure-database-parameters.html\">Configure Database Parameters and VCN Peering</a>."
-    default: false
-
-  oci_db_connection_string:
-    visible:
-      and:
-        - ${orm_create_mode}
-        - ${add_JRF}
-        - ${use_oci_db_connection_string}
-        - eq:
-            - ${db_strategy}
-            - "Database System"
-        - not:
-            - ${create_new_vcn}
-    type: string
-    title: "Oracle Database Connection String"
-    description: "Oracle database connection string to connect to database. Example: //{scan_hostname}.{host_domain_name}:{db_port}/{pdb_or_sid}.{Host Domain Name}"
-    pattern: ^(\/\/)
-    required: true
-
-  # ATP DB Configuration
-  atp_db_compartment_id:
-    visible:
-      and:
-        - ${orm_create_mode}
-        - ${add_JRF}
-        - eq:
-            - ${db_strategy}
-            - "Autonomous Transaction Processing Database"
-    type: oci:identity:compartment:id
-    required: true
-    title: "Autonomous Database Compartment"
-    description: "The compartment in which the Autonomous Transaction Processing (ATP) database is found"
-
-  atp_db_id:
-    visible:
-      and:
-        - ${orm_create_mode}
-        - ${add_JRF}
-        - eq:
-            - ${db_strategy}
-            - "Autonomous Transaction Processing Database"
-    type: oci:database:autonomousdatabase:id
-    dependsOn:
-      compartmentId: ${atp_db_compartment_id}
-    required: true
-    title: "Autonomous Database"
-    description: "The Autonomous Transaction Processing (ATP) database in which to provision the schemas for a JRF-enabled WebLogic Server domain"
-
-  atp_db_secret_compartment_id:
-    visible:
-      and:
-        - ${orm_create_mode}
-        - ${add_JRF}
-        - eq:
-            - ${db_strategy}
-            - "Autonomous Transaction Processing Database"
-    type: oci:identity:compartment:id
-    title: "Autonomous Database Secret Compartment"
-    description: "The compartment where you have the ATP database secret"
-    required: true
-    default: ${compartment_ocid}
-
-  atp_db_password_id:
-    visible:
-      and:
-        - ${orm_create_mode}
-        - ${add_JRF}
-        - eq:
-            - ${db_strategy}
-            - "Autonomous Transaction Processing Database"
-    type: "oci:kms:secret:id"
-    dependsOn:
-      compartmentId: ${atp_db_secret_compartment_id}
-    required: true
-    title: "Validated Secret for Autonomous Database Admin Password"
-    description: "The secret that contains the administration user password in the ATP database. To create secrets, see <a target=\"_blank\" href=\"https://docs.oracle.com/en/cloud/paas/weblogic-cloud/user/you-begin-oracle-weblogic-cloud.html#GUID-0517A019-4A89-40ED-A568-DD2193733F8B\"> Create Secrets for Passwords</a>."
-
-  atp_db_level:
-    visible:
-      and:
-        - ${orm_create_mode}
-        - ${add_JRF}
-        - eq:
-            - ${db_strategy}
-            - "Autonomous Transaction Processing Database"
-    type: enum
-    enum:
-      - low
-      - tp
-      - tpurgent
-    default: low
-    title: "Autonomous Database Service Level"
-    description: "The service level that the WebLogic Server domain should use to connect to the autonomous database. The default is low."
-
-  atp_db_uses_private_endpoint:
-    visible:
-      and:
-        - ${orm_create_mode}
-        - ${add_JRF}
-        - eq:
-            - ${db_strategy}
-            - "Autonomous Transaction Processing Database"
-    type: boolean
-    default: false
-    title: "Database uses private endpoint"
-    description: "The Autonomous Transaction Processing (ATP) database uses private endpoint for network access"
-
-  atp_db_network_compartment_id:
-    visible:
-      and:
-        - ${orm_create_mode}
-        - ${add_JRF}
-        - and:
-            - eq:
-                - ${db_strategy}
-                - "Autonomous Transaction Processing Database"
-            - ${atp_db_uses_private_endpoint}
-    type: oci:identity:compartment:id
-    required: true
-    title: "Autonomous Database Network Compartment"
-    description: "The compartment in which the ATP database Virtual Cloud Network is found"
-    default: ${compartment_ocid}
-
-  atp_db_existing_vcn_id:
-    visible:
-      and:
-        - ${orm_create_mode}
-        - ${add_JRF}
-        - and:
-            - eq:
-                - ${db_strategy}
-                - "Autonomous Transaction Processing Database"
-            - ${atp_db_uses_private_endpoint}
-    type: oci:core:vcn:id
-    dependsOn:
-      compartmentId: ${atp_db_network_compartment_id}
-    required: true
-    default: ''
-    title: "Autonomous Database Network"
-    description: "An existing Virtual Cloud Network (VCN) used by ATP database with private endpoint. If the selected VCN is different from WebLogic Server VCN then local VCN peering will be setup. When using VCN peering ensure that the VCNs being peered have non-overlapping CIDR blocks."
-
-  oci_db_network_compartment_id:
-    visible:
-      and:
-        - ${orm_create_mode}
-        - ${add_JRF}
-        - and:
-            - eq:
-                - ${db_strategy}
-                - "Database System"
-            - or:
-                - ${create_new_vcn}
-                - not:
-                    - ${use_oci_db_connection_string}
-    type: oci:identity:compartment:id
-    required: true
-    title: "DB System Network Compartment"
-    description: "The compartment in which the DB System Virtual Cloud Network is found"
-    default: ${compartment_ocid}
-
-  db_existing_vcn_add_secrule:
-    visible:
-      and:
-        - ${orm_create_mode}
-        - ${add_JRF}
-        - ${create_policies}
-        - or:
-            - and:
-                - eq:
-                    - ${db_strategy}
-                    - "Database System"
-                - or:
-                    - ${create_new_vcn}
-                    - not:
-                        - ${use_oci_db_connection_string}
-            - and:
-                - eq:
-                    - ${db_strategy}
-                    - "Autonomous Transaction Processing Database"
-                - ${atp_db_uses_private_endpoint}
-    type: boolean
-    default: true
-    title: "Create Database Security List"
-    description: "Add a security list to the DB subnet or a security rule to the Network Security Group for ATP Database with private endpoint that allows connections from the WebLogic Server subnet"
-
-  # OCI DB Configuration
-
-  oci_db_compartment_id:
-    visible:
-      and:
-        - ${orm_create_mode}
-        - ${add_JRF}
-        - and:
-            - eq:
-                - ${db_strategy}
-                - "Database System"
-            - or:
-                - ${create_new_vcn}
-                - not:
-                    - ${use_oci_db_connection_string}
-    type: oci:identity:compartment:id
-    required: true
-    title: "DB System Compartment"
-    description: "The compartment in which the DB System is found"
-    default: ${compartment_ocid}
-
-  oci_db_existing_vcn_id:
-    visible:
-      and:
-        - ${orm_create_mode}
-        - ${add_JRF}
-        - and:
-            - eq:
-                - ${db_strategy}
-                - "Database System"
-            - or:
-                - ${create_new_vcn}
-                - not:
-                    - ${use_oci_db_connection_string}
-    type: oci:core:vcn:id
-    dependsOn:
-      compartmentId: ${oci_db_network_compartment_id}
-    required: true
-    default: ''
-    title: "DB System Network"
-    description: "An existing Virtual Cloud Network (VCN) used by DB System. If the selected VCN is different from WebLogic Server VCN then local VCN peering will be setup. When using VCN peering ensure that the VCNs being peered have non-overlapping CIDR blocks."
-
-  oci_db_dbsystem_id:
-    visible:
-      and:
-        - ${orm_create_mode}
-        - ${add_JRF}
-        - and:
-            - eq:
-                - ${db_strategy}
-                - "Database System"
-            - or:
-                - ${create_new_vcn}
-                - not:
-                    - ${use_oci_db_connection_string}
-    type: oci:database:dbsystem:id
-    dependsOn:
-      compartmentId: ${oci_db_compartment_id}
-    required: true
-    title: "DB System"
-    description: "The Oracle Cloud Infrastructure DB System to use for this WebLogic Server domain"
-
-  oci_db_dbhome_id:
-    visible:
-      and:
-        - ${orm_create_mode}
-        - ${add_JRF}
-        - and:
-            - eq:
-                - ${db_strategy}
-                - "Database System"
-            - or:
-                - ${create_new_vcn}
-                - not:
-                    - ${use_oci_db_connection_string}
-    type: oci:database:dbhome:id
-    required: true
-    title: "Database home in the DB System"
-    description: "The database home within the DB System"
-    dependsOn:
-      compartmentId: ${oci_db_compartment_id}
-      dbSystemId: ${oci_db_dbsystem_id}
-
-  oci_db_dbhome_major_version:
-    visible:
-      and:
-        - ${orm_create_mode}
-        - ${add_JRF}
-        - and:
-            - eq:
-                - ${db_strategy}
-                - "Database System"
-            - or:
-                - ${create_new_vcn}
-                - not:
-                    - ${use_oci_db_connection_string}
-    type: oci:database:dbhome:dbversion
-    title: "Version of Database home in the DB System"
-    description: "The version of database home within the DB System"
-    dependsOn:
-      dbHomeId: ${oci_db_dbhome_id}
-
-  oci_db_database_id:
-    visible:
-      and:
-        - ${orm_create_mode}
-        - ${add_JRF}
-        - and:
-            - eq:
-                - ${db_strategy}
-                - "Database System"
-            - or:
-                - ${create_new_vcn}
-                - not:
-                    - ${use_oci_db_connection_string}
-    type: oci:database:database:id
-    dependsOn:
-      compartmentId: ${oci_db_compartment_id}
-      dbHomeId: ${oci_db_dbhome_id}
-    required: true
-    title: "Database in the DB System"
-    description: "The database within the DB System in which to provision the schemas for a JRF-enabled WebLogic Server domain"
-
-  oci_db_pdb_service_name:
-    visible:
-      and:
-        - ${orm_create_mode}
-        - ${add_JRF}
-        - and:
-            - not:
-                - eq:
-                    - ${oci_db_dbhome_major_version}
-                    - "11"
-            - eq:
-                - ${db_strategy}
-                - "Database System"
-
-    type: string
-    required: true
-    title: "PDB"
-    description: "The name of the pluggable database (PDB) in which to provision the schemas for a JRF-enabled WebLogic Server domain. This is required for Oracle Database 12c or later."
-
-  oci_db_user:
-    visible:
-      and:
-        - ${orm_create_mode}
-        - ${add_JRF}
-        - eq:
-            - ${db_strategy}
-            - "Database System"
-    type: string
-    default: SYS
-    pattern: "^[a-zA-Z][a-zA-Z0-9]{1,49}$"
-    minLength: 2
-    maxLength: 50
-    title: "Database Administrator"
-    description: "The name of a database user with SYSDBA privileges"
-    required: true
-
-  oci_db_port:
-    visible:
-      and:
-        - ${orm_create_mode}
-        - ${add_JRF}
-        - and:
-            - eq:
-                - ${db_strategy}
-                - "Database System"
-            - or:
-                - ${create_new_vcn}
-                - not:
-                    - ${use_oci_db_connection_string}
-    type: integer
-    default: 1521
-    title: "Database Listener Port"
-    description: "The Listener Port for the Database"
-    required: false
-
-  oci_db_secret_compartment_id:
-    visible:
-      and:
-        - ${orm_create_mode}
-        - ${add_JRF}
-        - eq:
-            - ${db_strategy}
-            - "Database System"
-    type: oci:identity:compartment:id
-    title: "OCI DB Admin Password Secret Compartment"
-    description: "The compartment where you have the OCI DB administration password secret"
-    required: true
-    default: ${compartment_ocid}
-
-  oci_db_password_id:
-    visible:
-      and:
-        - ${orm_create_mode}
-        - ${add_JRF}
-        - eq:
-            - ${db_strategy}
-            - "Database System"
-    type: "oci:kms:secret:id"
-    dependsOn:
-      compartmentId: ${oci_db_secret_compartment_id}
-    required: true
-    title: "Validated Secret for OCI DB Admin Password"
-    description: "The secret that contains the database administration password. To create secrets, see <a target=\"_blank\" href=\"https://docs.oracle.com/en/cloud/paas/weblogic-cloud/user/you-begin-oracle-weblogic-cloud.html#GUID-0517A019-4A89-40ED-A568-DD2193733F8B\"> Create Secrets for Passwords</a>."
-
-  db_vcn_lpg_id:
-    visible:
-      and:
-        - ${add_JRF}
-        - or:
-          - and:
-              - eq:
-                  - ${db_strategy}
-                  - "Database System"
-              - not:
-                  - ${use_oci_db_connection_string}
-              - or:
-                  - ${create_new_vcn}
-                  - and:
-                      - ${create_new_subnets}
-                      - not:
-                          - eq:
-                              - ${wls_existing_vcn_id}
-                              - ${oci_db_existing_vcn_id}
-          - and:
-              - eq:
-                  - ${db_strategy}
-                  - "Autonomous Transaction Processing Database"
-              - ${atp_db_uses_private_endpoint}
-              - or:
-                  - ${create_new_vcn}
-                  - and:
-                      - ${create_new_subnets}
-                      - not:
-                          - eq:
-                              - ${wls_existing_vcn_id}
-                              - ${atp_db_existing_vcn_id}
-
-    type: string
-    title: "Local Peering Gateway in Database VCN"
-    pattern: ^ocid1.localpeeringgateway.*$
-    required: true
-    description: "The OCID of the Local Peering Gateway (LPG) in the database VCN, used to peer the WebLogic VCN"
-
   # Tagging variables
   create_service_tag:
     visible: ${orm_create_mode}
@@ -2389,7 +1927,6 @@ variables:
     description: "The Oracle Cloud Identifier (OCID) of your existing file system. The existing file system must be in the same availability domain as the existing mount target."
     pattern: ^$|^ocid1.filesystem.*$
     required: true
-
 
   use_oci_logging:
     type: boolean

--- a/terraform/weblogic_variables.tf
+++ b/terraform/weblogic_variables.tf
@@ -1,13 +1,13 @@
-# Copyright (c) 2023, 2024, Oracle and/or its affiliates.
+# Copyright (c) 2023, 2024, 2025, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 variable "wls_version" {
   type        = string
-  description = "The WebLogic version to be installed for this stack. Accepted values are: 12.2.1.4, 14.1.1.0, 14.1.2.0"
+  description = "The WebLogic version to be installed for this stack. Accepted values are: 12.2.1.4, 14.1.1.0, 14.1.2.0, 15.1.1.0"
   default     = "12.2.1.4"
   validation {
-    condition     = contains(["12.2.1.4", "14.1.1.0","14.1.2.0"], var.wls_version)
-    error_message = "WLSC-ERROR: Allowed values for wls_version are 12.2.1.4, 14.1.1.0 & 14.1.2.0."
+    condition     = contains(["12.2.1.4", "14.1.1.0","14.1.2.0","15.1.1.0"], var.wls_version)
+    error_message = "WLSC-ERROR: Allowed values for wls_version are 12.2.1.4, 14.1.1.0, 14.1.2.0, 15.1.1.0."
   }
 }
 
@@ -67,6 +67,16 @@ variable "wls_14120_jdk_version" {
   validation {
     condition     = contains(["jdk17", "jdk21"], var.wls_14120_jdk_version)
     error_message = "WLSC-ERROR: Allowed values for wls_14120_jdk_version are jdk17, jdk21."
+  }
+}
+
+variable "wls_15110_jdk_version" {
+  type        = string
+  description = "JDK version to use when installing WebLogic 15.1.1.0 version. Ignored when WebLogic version is not 15.1.1.0. Allowed values: jdk21, jdk17"
+  default     = "jdk17"
+  validation {
+    condition     = contains(["jdk17", "jdk21"], var.wls_15110_jdk_version)
+    error_message = "WLSC-ERROR: Allowed values for wls_15110_jdk_version are jdk17, jdk21."
   }
 }
 

--- a/terraform/weblogic_variables.tf
+++ b/terraform/weblogic_variables.tf
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, 2024, 2025, Oracle and/or its affiliates.
+# Copyright (c) 2023, 2025, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 variable "wls_version" {


### PR DESCRIPTION
Add support for WLS 15.1.1.0

Notes for reviewers:
- WLS 15.1.1.0 will not support JRF
- WLS 15.1.1.0 supports JDK17 and JDK21 (just like 14.1.2.0)
- WLS 15.1.1.0 supports integration with OCI certificate service, but this was not incorporated since this new feature is a "technical preview". When GA we can incorporate this.

Testing:
Based on the areas where code changes were made I ran the following tests:
- Non-secured mode 15.1.1.0 2 node provisioning with JDK 17.
- Secured production mode 15.1.1.0 2 node provisioning with JDK21.
- IDCS multi-node provisioning with secured production mode. Although no code changed, this was to verify authentication provider and appgateway still worked as expected with this new WLS version.
- 14.1.2.0 secured production mode with JRF. This was tested to confirm no regressions.