### PR TITLE
Fix policy creation failure with existing OSMH profile

### DIFF
--- a/terraform/data_sources.tf
+++ b/terraform/data_sources.tf
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, 2024, Oracle and/or its affiliates.
+# Copyright (c) 2023, 2025, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 data "oci_identity_regions" "home_region" {

--- a/terraform/data_sources.tf
+++ b/terraform/data_sources.tf
@@ -215,3 +215,10 @@ data "oci_certificates_management_certificate_authority" "root_certificate_autho
   certificate_authority_id = var.root_ca_id
 }
 
+data "oci_os_management_hub_profile" "osmh_profile" {
+  count = var.select_existing_profile ? 1 : 0
+
+  #Required
+  profile_id = var.profile_ocid
+}
+

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -197,7 +197,7 @@ locals {
   select_existing_profile         = var.select_existing_profile
   create_profile                  = (local.enable_osmh && !local.select_existing_profile) ? true : false
   profile_ocid                    = local.select_existing_profile ? var.profile_ocid : ""
-  profile_compartment_id          = var.profile_compartment_id == "" ? var.compartment_ocid : var.profile_compartment_id
+  profile_compartment_id          = var.profile_compartment_id == "" ? (var.select_existing_profile ? data.oci_os_management_hub_profile.osmh_profile[0].compartment_id : var.compartment_ocid) : var.profile_compartment_id
   profile_name                    = var.profile_name == "" ? format("%s_profile", local.service_name_prefix) : var.profile_name
 
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -239,7 +239,7 @@ module "policies" {
   apm_domain_compartment_id        = local.apm_domain_compartment_id
   use_autoscaling                  = var.use_autoscaling
   enable_osmh                      = var.enable_osmh
-  profile_compartment_id           = var.profile_compartment_id
+  profile_compartment_id           = local.profile_compartment_id
 
   ocir_auth_token_id               = var.ocir_auth_token_id
   add_fss                          = var.add_fss


### PR DESCRIPTION
This PR contains a fix for policy creation failure with existing OSMH profile.

`Error: 400-InvalidParameter, Invalid parameter
Suggestion: Please update the parameter(s) in the Terraform config as per error message Invalid parameter
Documentation: https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/identity_policy
API Reference: https://docs.oracle.com/iaas/api/#/en/identity/20160918/Policy/CreatePolicy
Request Target: POST https://identity.us-ashburn-1.oci.oraclecloud.com/20160918/policies
Provider version: 6.34.0, released on 2025-04-13. This provider is 26 Update(s) behind to current.
Service: Identity Policy
Operation Name: CreatePolicy
OPC request ID: 8d7040298fd49d6addf2e0859c30708a/7196FAAE5D9F27716D603FB2817FDAAB/37D5DA71DCD77910BD68A787D4CC7B04
  with module.policies[0].oci_identity_policy.wlsc_oci_policy,
  on modules/policies/wlsc_policies.tf line 4, in resource "oci_identity_policy" "wlsc_oci_policy" 
   4: resource "oci_identity_policy" "wlsc_oci_policy" {`

Testing done : 
1. Tested provisioning with existing OSMH profile in same compartment as the stack - Provisioning successful
2. Tested provisioning with existing OSMH profile in different compartment then the stack - Provisioning successful
3. Tested provisioning with new OSMH profile in different compartment then the stack - Provisioning successful