### PR TITLE
Removing the option of APM in edit stack

### DIFF
--- a/terraform/schema.yaml
+++ b/terraform/schema.yaml
@@ -2443,9 +2443,11 @@ variables:
 
   apm_domain_compartment_id:
     visible:
-      -or:
-        - ${use_apm_service}
-        - ${use_autoscaling}
+      and:
+        - ${orm_create_mode}
+        - or:
+            - ${use_apm_service}
+            - ${use_autoscaling}
     type: oci:identity:compartment:id
     title: "Application Performance Monitoring Domain Compartment"
     description: "The compartment where you have the Application Performance Monitoring domain to be used by this WebLogic instance"
@@ -2454,9 +2456,11 @@ variables:
 
   apm_domain_id:
     visible:
-      -or:
-        - ${use_apm_service}
-        - ${use_autoscaling}
+      and:
+        - ${orm_create_mode}
+        - or:
+            - ${use_apm_service}
+            - ${use_autoscaling}
     type: oci:apm:domain:id
     title: "Application Performance Monitoring Domain"
     description: "The Application Performance Monitoring domain used by this WebLogic instance"
@@ -2466,9 +2470,11 @@ variables:
 
   apm_private_data_key_name:
     visible:
-      -or:
-        - ${use_apm_service}
-        - ${use_autoscaling}
+      and:
+        - ${orm_create_mode}
+        - or:
+            - ${use_apm_service}
+            - ${use_autoscaling}
     type: string
     title: "Application Performance Monitoring Private Data Key Name"
     description: "The name of the private data key used by this WebLogic instance to push metrics to the Application Performance Monitoring domain"

--- a/terraform/schema.yaml
+++ b/terraform/schema.yaml
@@ -2440,6 +2440,7 @@ variables:
     default: false
     title: "Enable Application Performance Monitoring"
     description: "Enable Application Performance Monitoring for WebLogic instances, which is required for automatic scaling of the stack. If you automatically scale the stack, you must not unselect the Enable Application Performance Monitoring option when editing the stack."
+    visible: ${orm_create_mode}
 
   apm_domain_compartment_id:
     visible:

--- a/terraform/schema_14110.yaml
+++ b/terraform/schema_14110.yaml
@@ -1980,9 +1980,11 @@ variables:
 
   apm_domain_compartment_id:
     visible:
-      -or:
-        - ${use_apm_service}
-        - ${use_autoscaling}
+      and:
+        - ${orm_create_mode}
+        - or:
+            - ${use_apm_service}
+            - ${use_autoscaling}
     type: oci:identity:compartment:id
     title: "Application Performance Monitoring Domain Compartment"
     description: "The compartment where you have the Application Performance Monitoring domain to be used by this WebLogic instance"
@@ -1991,9 +1993,11 @@ variables:
 
   apm_domain_id:
     visible:
-      -or:
-        - ${use_apm_service}
-        - ${use_autoscaling}
+      and:
+        - ${orm_create_mode}
+        - or:
+            - ${use_apm_service}
+            - ${use_autoscaling}
     type: oci:apm:domain:id
     title: "Application Performance Monitoring Domain"
     description: "The Application Performance Monitoring domain used by this WebLogic instance"
@@ -2003,9 +2007,11 @@ variables:
 
   apm_private_data_key_name:
     visible:
-      -or:
-        - ${use_apm_service}
-        - ${use_autoscaling}
+      and:
+        - ${orm_create_mode}
+        - or:
+            - ${use_apm_service}
+            - ${use_autoscaling}
     type: string
     title: "Application Performance Monitoring Private Data Key Name"
     description: "The name of the private data key used by this WebLogic instance to push metrics to the Application Performance Monitoring domain"

--- a/terraform/schema_14110.yaml
+++ b/terraform/schema_14110.yaml
@@ -1977,6 +1977,7 @@ variables:
     default: false
     title: "Enable Application Performance Monitoring"
     description: "Enable Application Performance Monitoring for WebLogic instances, which is required for automatic scaling of the stack. If you automatically scale the stack, you must not unselect the Enable Application Performance Monitoring option when editing the stack."
+    visible: ${orm_create_mode}
 
   apm_domain_compartment_id:
     visible:

--- a/terraform/schema_14120.yaml
+++ b/terraform/schema_14120.yaml
@@ -2449,6 +2449,7 @@ variables:
     default: false
     title: "Enable Application Performance Monitoring"
     description: "Enable Application Performance Monitoring for WebLogic instances, which is required for automatic scaling of the stack. If you automatically scale the stack, you must not unselect the Enable Application Performance Monitoring option when editing the stack."
+    visible: ${orm_create_mode}
 
   apm_domain_compartment_id:
     visible:

--- a/terraform/schema_14120.yaml
+++ b/terraform/schema_14120.yaml
@@ -2452,9 +2452,11 @@ variables:
 
   apm_domain_compartment_id:
     visible:
-      -or:
-        - ${use_apm_service}
-        - ${use_autoscaling}
+      and:
+        - ${orm_create_mode}
+        - or:
+            - ${use_apm_service}
+            - ${use_autoscaling}
     type: oci:identity:compartment:id
     title: "Application Performance Monitoring Domain Compartment"
     description: "The compartment where you have the Application Performance Monitoring domain to be used by this WebLogic instance"
@@ -2463,9 +2465,11 @@ variables:
 
   apm_domain_id:
     visible:
-      -or:
-        - ${use_apm_service}
-        - ${use_autoscaling}
+      and:
+        - ${orm_create_mode}
+        - or:
+            - ${use_apm_service}
+            - ${use_autoscaling}
     type: oci:apm:domain:id
     title: "Application Performance Monitoring Domain"
     description: "The Application Performance Monitoring domain used by this WebLogic instance"
@@ -2475,9 +2479,11 @@ variables:
 
   apm_private_data_key_name:
     visible:
-      -or:
-        - ${use_apm_service}
-        - ${use_autoscaling}
+      and:
+        - ${orm_create_mode}
+        - or:
+            - ${use_apm_service}
+            - ${use_autoscaling}
     type: string
     title: "Application Performance Monitoring Private Data Key Name"
     description: "The name of the private data key used by this WebLogic instance to push metrics to the Application Performance Monitoring domain"

--- a/terraform/schema_15110.yaml
+++ b/terraform/schema_15110.yaml
@@ -1980,9 +1980,11 @@ variables:
 
   apm_domain_compartment_id:
     visible:
-      -or:
-        - ${use_apm_service}
-        - ${use_autoscaling}
+      and:
+        - ${orm_create_mode}
+        - or:
+          - ${use_apm_service}
+          - ${use_autoscaling}
     type: oci:identity:compartment:id
     title: "Application Performance Monitoring Domain Compartment"
     description: "The compartment where you have the Application Performance Monitoring domain to be used by this WebLogic instance"
@@ -1991,9 +1993,11 @@ variables:
 
   apm_domain_id:
     visible:
-      -or:
-        - ${use_apm_service}
-        - ${use_autoscaling}
+      and:
+        - ${orm_create_mode}
+        - or:
+            - ${use_apm_service}
+            - ${use_autoscaling}
     type: oci:apm:domain:id
     title: "Application Performance Monitoring Domain"
     description: "The Application Performance Monitoring domain used by this WebLogic instance"
@@ -2003,9 +2007,11 @@ variables:
 
   apm_private_data_key_name:
     visible:
-      -or:
-        - ${use_apm_service}
-        - ${use_autoscaling}
+      and:
+        - ${orm_create_mode}
+        - or:
+            - ${use_apm_service}
+            - ${use_autoscaling}
     type: string
     title: "Application Performance Monitoring Private Data Key Name"
     description: "The name of the private data key used by this WebLogic instance to push metrics to the Application Performance Monitoring domain"

--- a/terraform/schema_15110.yaml
+++ b/terraform/schema_15110.yaml
@@ -1977,7 +1977,8 @@ variables:
     default: false
     title: "Enable Application Performance Monitoring"
     description: "Enable Application Performance Monitoring for WebLogic instances, which is required for automatic scaling of the stack. If you automatically scale the stack, you must not unselect the Enable Application Performance Monitoring option when editing the stack."
-
+    visible: ${orm_create_mode}
+    
   apm_domain_compartment_id:
     visible:
       and:


### PR DESCRIPTION
Currently when editing a stack the option to "Enable Application Performance Monitoring" is presented. The decision is made to hide the option while editing the stack. In this MR, we will be making changes to the terraform to present the option of APM only during the creation of stack.

Testing - 
a.) Created the stack with APM enabled. Verified that the APM agent is added on all the servers and its being monitored by APM from dashboard.
b.) Scaled up the nodes and verified that the APM agent was installed on the newly added server and that is being shown in the APM dashboard for monitoring.
c.) Verified from the UI that the checkbox of APM is being disabled in the edit stack screen
