### PR TITLE
Topic ocir user edit

### DIFF
--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -160,8 +160,7 @@ locals {
   ocir_namespace = data.oci_objectstorage_namespace.object_namespace.namespace
 
   ocir_namespace_with_slash = format("%s/", local.ocir_namespace)
-  ocir_user_starts_with     = substr(var.ocir_user, 0, length(local.ocir_namespace_with_slash))
-  ocir_user                 = local.ocir_user_starts_with == local.ocir_namespace_with_slash ? var.ocir_user : "${format("%s%s", local.ocir_namespace_with_slash, var.ocir_user)}"
+  ocir_user                 = length(regexall("/", var.ocir_user)) > 0 ? var.ocir_user : "${format("%s%s", local.ocir_namespace_with_slash, var.ocir_user)}"
 
   region_keys         = data.oci_identity_regions.all_regions.regions.*.key
   region_names        = data.oci_identity_regions.all_regions.regions.*.name

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -160,7 +160,9 @@ locals {
   ocir_namespace = data.oci_objectstorage_namespace.object_namespace.namespace
 
   ocir_namespace_with_slash = format("%s/", local.ocir_namespace)
-  ocir_user                 = length(regexall("/", var.ocir_user)) > 0 ? var.ocir_user : "${format("%s%s", local.ocir_namespace_with_slash, var.ocir_user)}"
+  ocir_user_starts_with     = substr(var.ocir_user, 0, length(local.ocir_namespace_with_slash)) == local.ocir_namespace_with_slash
+  ocir_user_boat_access     = strcontains(var.ocir_user, "bmc_operator_access")
+  ocir_user                 = (local.ocir_user_boat_access || local.ocir_user_starts_with) ? var.ocir_user : "${format("%s%s", local.ocir_namespace_with_slash, var.ocir_user)}"
 
   region_keys         = data.oci_identity_regions.all_regions.regions.*.key
   region_names        = data.oci_identity_regions.all_regions.regions.*.name

--- a/terraform/schema.yaml
+++ b/terraform/schema.yaml
@@ -2601,7 +2601,7 @@ variables:
             - ${use_autoscaling}
     type: string
     title: "Registry User Name"
-    description: "The user name to access the Oracle Cloud Infrastructure Registry (OCIR) for deploying autoscaling OCI functions, which has the format either {username} or {tenancy_namespace}/{identity domain name}/{username}. If your tenancy is using Oracle Identity Cloud Service, use the format {tenancy_namespace}/oracleidentitycloudservice/{username}."
+    description: "The user name to access the Oracle Cloud Infrastructure Registry (OCIR) for deploying autoscaling OCI functions. If the user is in an identity domain, use the format {tenancy_namespace}/{identity domain name}/{username}, otherwise use the format {username}.  If your tenancy is using Oracle Identity Cloud Service, use the format {tenancy_namespace}/oracleidentitycloudservice/{username}."
     required: true
 
   ocir_auth_token_compartment_id:

--- a/terraform/schema.yaml
+++ b/terraform/schema.yaml
@@ -2601,7 +2601,7 @@ variables:
             - ${use_autoscaling}
     type: string
     title: "Registry User Name"
-    description: "The user name to access the Oracle Cloud Infrastructure Registry (OCIR) for deploying autoscaling OCI functions, which has the format {identity domain name}/{username}. If your tenancy is using Oracle Identity Cloud Service, use the format oracleidentitycloudservice/{username}."
+    description: "The user name to access the Oracle Cloud Infrastructure Registry (OCIR) for deploying autoscaling OCI functions, which has the format either {username} or {tenancy_namespace}/{identity domain name}/{username}. If your tenancy is using Oracle Identity Cloud Service, use the format {tenancy_namespace}/oracleidentitycloudservice/{username}."
     required: true
 
   ocir_auth_token_compartment_id:

--- a/terraform/schema.yaml
+++ b/terraform/schema.yaml
@@ -2601,7 +2601,7 @@ variables:
             - ${use_autoscaling}
     type: string
     title: "Registry User Name"
-    description: "The user name to access the Oracle Cloud Infrastructure Registry (OCIR) for deploying autoscaling OCI functions. If the user is in an identity domain, use the format {tenancy_namespace}/{identity domain name}/{username}, otherwise use the format {username}.  If your tenancy is using Oracle Identity Cloud Service, use the format {tenancy_namespace}/oracleidentitycloudservice/{username}."
+    description: "The user name to access the Oracle Cloud Infrastructure Registry (OCIR) for deploying autoscaling OCI functions, which has the format {identity domain name}/{username}. If the user is in the default identity domain, do not include the identity domain name and use the format {username}. Or for example if your tenancy is using Oracle Identity Cloud Service, use the format {tenancy_namespace}/oracleidentitycloudservice/{username}."
     required: true
 
   ocir_auth_token_compartment_id:

--- a/terraform/schema.yaml
+++ b/terraform/schema.yaml
@@ -2601,7 +2601,7 @@ variables:
             - ${use_autoscaling}
     type: string
     title: "Registry User Name"
-    description: "The user name to access the Oracle Cloud Infrastructure Registry (OCIR) for deploying autoscaling OCI functions, which has the format {identity domain name}/{username}. If the user is in the default identity domain, do not include the identity domain name and use the format {username}. Or for example if your tenancy is using Oracle Identity Cloud Service, use the format {tenancy_namespace}/oracleidentitycloudservice/{username}."
+    description: "The user name to access the Oracle Cloud Infrastructure Registry (OCIR) for deploying autoscaling OCI functions has the format {tenancy namespace}{identity domain name}/{user name}. If the user is in the Default identity domain, do not include {identity domain name}. If you do not know the tenancy namespace do not add {tenancy_namespace} and let the stack set this for you. For example, if you don't know your tenancy namespace and your tenancy is federated with Oracle Identity Cloud Service with an identity domain of oracleidentitycloudservice you would set oracleidentitycloudservice/{username}."
     required: true
 
   ocir_auth_token_compartment_id:

--- a/terraform/schema.yaml
+++ b/terraform/schema.yaml
@@ -2601,7 +2601,7 @@ variables:
             - ${use_autoscaling}
     type: string
     title: "Registry User Name"
-    description: "The user name to access the Oracle Cloud Infrastructure Registry (OCIR) for deploying autoscaling OCI functions has the format {tenancy namespace}{identity domain name}/{user name}. If the user is in the Default identity domain, do not include {identity domain name}. If you do not know the tenancy namespace do not add {tenancy_namespace} and let the stack set this for you. For example, if you don't know your tenancy namespace and your tenancy is federated with Oracle Identity Cloud Service with an identity domain of oracleidentitycloudservice you would set oracleidentitycloudservice/{username}."
+    description: "The user name to access the Oracle Cloud Infrastructure Registry (OCIR) for deploying autoscaling OCI functions has the format {tenancy namespace}/{identity domain name}/{user name}. If the user is in the Default identity domain, do not include {identity domain name}. If you do not know the tenancy namespace do not add {tenancy_namespace} and let the stack set this for you. For example, if you don't know your tenancy namespace and your tenancy is federated with Oracle Identity Cloud Service with an identity domain of oracleidentitycloudservice you would set oracleidentitycloudservice/{username}."
     required: true
 
   ocir_auth_token_compartment_id:

--- a/terraform/schema_14110.yaml
+++ b/terraform/schema_14110.yaml
@@ -2138,7 +2138,7 @@ variables:
             - ${use_autoscaling}
     type: string
     title: "Registry User Name"
-    description: "The user name to access the Oracle Cloud Infrastructure Registry (OCIR) for deploying autoscaling OCI functions, which has the format {identity domain name}/{username}. If your tenancy is using Oracle Identity Cloud Service, use the format oracleidentitycloudservice/{username}."
+    description: "The user name to access the Oracle Cloud Infrastructure Registry (OCIR) for deploying autoscaling OCI functions, which has the format either {username} or {tenancy_namespace}/{identity domain name}/{username}. If your tenancy is using Oracle Identity Cloud Service, use the format {tenancy_namespace}/oracleidentitycloudservice/{username}."
     required: true
 
   ocir_auth_token_compartment_id:

--- a/terraform/schema_14110.yaml
+++ b/terraform/schema_14110.yaml
@@ -2138,7 +2138,7 @@ variables:
             - ${use_autoscaling}
     type: string
     title: "Registry User Name"
-    description: "The user name to access the Oracle Cloud Infrastructure Registry (OCIR) for deploying autoscaling OCI functions, which has the format either {username} or {tenancy_namespace}/{identity domain name}/{username}. If your tenancy is using Oracle Identity Cloud Service, use the format {tenancy_namespace}/oracleidentitycloudservice/{username}."
+    description: "The user name to access the Oracle Cloud Infrastructure Registry (OCIR) for deploying autoscaling OCI functions. If the user is in an identity domain, use the format {tenancy_namespace}/{identity domain name}/{username}, otherwise use the format {username}.  If your tenancy is using Oracle Identity Cloud Service, use the format {tenancy_namespace}/oracleidentitycloudservice/{username}."
     required: true
 
   ocir_auth_token_compartment_id:

--- a/terraform/schema_14110.yaml
+++ b/terraform/schema_14110.yaml
@@ -2138,7 +2138,7 @@ variables:
             - ${use_autoscaling}
     type: string
     title: "Registry User Name"
-    description: "The user name to access the Oracle Cloud Infrastructure Registry (OCIR) for deploying autoscaling OCI functions. If the user is in an identity domain, use the format {tenancy_namespace}/{identity domain name}/{username}, otherwise use the format {username}.  If your tenancy is using Oracle Identity Cloud Service, use the format {tenancy_namespace}/oracleidentitycloudservice/{username}."
+    description: "The user name to access the Oracle Cloud Infrastructure Registry (OCIR) for deploying autoscaling OCI functions, which has the format {identity domain name}/{username}. If the user is in the default identity domain, do not include the identity domain name and use the format {username}. Or for example if your tenancy is using Oracle Identity Cloud Service, use the format {tenancy_namespace}/oracleidentitycloudservice/{username}."
     required: true
 
   ocir_auth_token_compartment_id:

--- a/terraform/schema_14110.yaml
+++ b/terraform/schema_14110.yaml
@@ -2138,7 +2138,7 @@ variables:
             - ${use_autoscaling}
     type: string
     title: "Registry User Name"
-    description: "The user name to access the Oracle Cloud Infrastructure Registry (OCIR) for deploying autoscaling OCI functions, which has the format {identity domain name}/{username}. If the user is in the default identity domain, do not include the identity domain name and use the format {username}. Or for example if your tenancy is using Oracle Identity Cloud Service, use the format {tenancy_namespace}/oracleidentitycloudservice/{username}."
+    description: "The user name to access the Oracle Cloud Infrastructure Registry (OCIR) for deploying autoscaling OCI functions has the format {tenancy namespace}{identity domain name}/{user name}. If the user is in the Default identity domain, do not include {identity domain name}. If you do not know the tenancy namespace do not add {tenancy_namespace} and let the stack set this for you. For example, if you don't know your tenancy namespace and your tenancy is federated with Oracle Identity Cloud Service with an identity domain of oracleidentitycloudservice you would set oracleidentitycloudservice/{username}."
     required: true
 
   ocir_auth_token_compartment_id:

--- a/terraform/schema_14110.yaml
+++ b/terraform/schema_14110.yaml
@@ -2138,7 +2138,7 @@ variables:
             - ${use_autoscaling}
     type: string
     title: "Registry User Name"
-    description: "The user name to access the Oracle Cloud Infrastructure Registry (OCIR) for deploying autoscaling OCI functions has the format {tenancy namespace}{identity domain name}/{user name}. If the user is in the Default identity domain, do not include {identity domain name}. If you do not know the tenancy namespace do not add {tenancy_namespace} and let the stack set this for you. For example, if you don't know your tenancy namespace and your tenancy is federated with Oracle Identity Cloud Service with an identity domain of oracleidentitycloudservice you would set oracleidentitycloudservice/{username}."
+    description: "The user name to access the Oracle Cloud Infrastructure Registry (OCIR) for deploying autoscaling OCI functions has the format {tenancy namespace}/{identity domain name}/{user name}. If the user is in the Default identity domain, do not include {identity domain name}. If you do not know the tenancy namespace do not add {tenancy_namespace} and let the stack set this for you. For example, if you don't know your tenancy namespace and your tenancy is federated with Oracle Identity Cloud Service with an identity domain of oracleidentitycloudservice you would set oracleidentitycloudservice/{username}."
     required: true
 
   ocir_auth_token_compartment_id:

--- a/terraform/schema_14120.yaml
+++ b/terraform/schema_14120.yaml
@@ -2610,7 +2610,7 @@ variables:
             - ${use_autoscaling}
     type: string
     title: "Registry User Name"
-    description: "The user name to access the Oracle Cloud Infrastructure Registry (OCIR) for deploying autoscaling OCI functions. If the user is in an identity domain, use the format {tenancy_namespace}/{identity domain name}/{username}, otherwise use the format {username}.  If your tenancy is using Oracle Identity Cloud Service, use the format {tenancy_namespace}/oracleidentitycloudservice/{username}."
+    description: "The user name to access the Oracle Cloud Infrastructure Registry (OCIR) for deploying autoscaling OCI functions, which has the format {identity domain name}/{username}. If the user is in the default identity domain, do not include the identity domain name and use the format {username}. Or for example if your tenancy is using Oracle Identity Cloud Service, use the format {tenancy_namespace}/oracleidentitycloudservice/{username}."
     required: true
 
   ocir_auth_token_compartment_id:

--- a/terraform/schema_14120.yaml
+++ b/terraform/schema_14120.yaml
@@ -2610,7 +2610,7 @@ variables:
             - ${use_autoscaling}
     type: string
     title: "Registry User Name"
-    description: "The user name to access the Oracle Cloud Infrastructure Registry (OCIR) for deploying autoscaling OCI functions has the format {tenancy namespace}{identity domain name}/{user name}. If the user is in the Default identity domain, do not include {identity domain name}. If you do not know the tenancy namespace do not add {tenancy_namespace} and let the stack set this for you. For example, if you don't know your tenancy namespace and your tenancy is federated with Oracle Identity Cloud Service with an identity domain of oracleidentitycloudservice you would set oracleidentitycloudservice/{username}."
+    description: "The user name to access the Oracle Cloud Infrastructure Registry (OCIR) for deploying autoscaling OCI functions has the format {tenancy namespace}/{identity domain name}/{user name}. If the user is in the Default identity domain, do not include {identity domain name}. If you do not know the tenancy namespace do not add {tenancy_namespace} and let the stack set this for you. For example, if you don't know your tenancy namespace and your tenancy is federated with Oracle Identity Cloud Service with an identity domain of oracleidentitycloudservice you would set oracleidentitycloudservice/{username}."
     required: true
 
   ocir_auth_token_compartment_id:

--- a/terraform/schema_14120.yaml
+++ b/terraform/schema_14120.yaml
@@ -2610,7 +2610,7 @@ variables:
             - ${use_autoscaling}
     type: string
     title: "Registry User Name"
-    description: "The user name to access the Oracle Cloud Infrastructure Registry (OCIR) for deploying autoscaling OCI functions, which has the format {identity domain name}/{username}. If the user is in the default identity domain, do not include the identity domain name and use the format {username}. Or for example if your tenancy is using Oracle Identity Cloud Service, use the format {tenancy_namespace}/oracleidentitycloudservice/{username}."
+    description: "The user name to access the Oracle Cloud Infrastructure Registry (OCIR) for deploying autoscaling OCI functions has the format {tenancy namespace}{identity domain name}/{user name}. If the user is in the Default identity domain, do not include {identity domain name}. If you do not know the tenancy namespace do not add {tenancy_namespace} and let the stack set this for you. For example, if you don't know your tenancy namespace and your tenancy is federated with Oracle Identity Cloud Service with an identity domain of oracleidentitycloudservice you would set oracleidentitycloudservice/{username}."
     required: true
 
   ocir_auth_token_compartment_id:

--- a/terraform/schema_14120.yaml
+++ b/terraform/schema_14120.yaml
@@ -2610,7 +2610,7 @@ variables:
             - ${use_autoscaling}
     type: string
     title: "Registry User Name"
-    description: "The user name to access the Oracle Cloud Infrastructure Registry (OCIR) for deploying autoscaling OCI functions, which has the format either {username} or {tenancy_namespace}/{identity domain name}/{username}. If your tenancy is using Oracle Identity Cloud Service, use the format {tenancy_namespace}/oracleidentitycloudservice/{username}."
+    description: "The user name to access the Oracle Cloud Infrastructure Registry (OCIR) for deploying autoscaling OCI functions. If the user is in an identity domain, use the format {tenancy_namespace}/{identity domain name}/{username}, otherwise use the format {username}.  If your tenancy is using Oracle Identity Cloud Service, use the format {tenancy_namespace}/oracleidentitycloudservice/{username}."
     required: true
 
   ocir_auth_token_compartment_id:

--- a/terraform/schema_14120.yaml
+++ b/terraform/schema_14120.yaml
@@ -2610,7 +2610,7 @@ variables:
             - ${use_autoscaling}
     type: string
     title: "Registry User Name"
-    description: "The user name to access the Oracle Cloud Infrastructure Registry (OCIR) for deploying autoscaling OCI functions, which has the format {identity domain name}/{username}. If your tenancy is using Oracle Identity Cloud Service, use the format oracleidentitycloudservice/{username}."
+    description: "The user name to access the Oracle Cloud Infrastructure Registry (OCIR) for deploying autoscaling OCI functions, which has the format either {username} or {tenancy_namespace}/{identity domain name}/{username}. If your tenancy is using Oracle Identity Cloud Service, use the format {tenancy_namespace}/oracleidentitycloudservice/{username}."
     required: true
 
   ocir_auth_token_compartment_id:

--- a/terraform/schema_15110.yaml
+++ b/terraform/schema_15110.yaml
@@ -2138,7 +2138,7 @@ variables:
             - ${use_autoscaling}
     type: string
     title: "Registry User Name"
-    description: "The user name to access the Oracle Cloud Infrastructure Registry (OCIR) for deploying autoscaling OCI functions, which has the format {identity domain name}/{username}. If your tenancy is using Oracle Identity Cloud Service, use the format oracleidentitycloudservice/{username}."
+    description: "The user name to access the Oracle Cloud Infrastructure Registry (OCIR) for deploying autoscaling OCI functions, which has the format either {username} or {tenancy_namespace}/{identity domain name}/{username}. If your tenancy is using Oracle Identity Cloud Service, use the format {tenancy_namespace}/oracleidentitycloudservice/{username}."
     required: true
 
   ocir_auth_token_compartment_id:

--- a/terraform/schema_15110.yaml
+++ b/terraform/schema_15110.yaml
@@ -2138,7 +2138,7 @@ variables:
             - ${use_autoscaling}
     type: string
     title: "Registry User Name"
-    description: "The user name to access the Oracle Cloud Infrastructure Registry (OCIR) for deploying autoscaling OCI functions, which has the format either {username} or {tenancy_namespace}/{identity domain name}/{username}. If your tenancy is using Oracle Identity Cloud Service, use the format {tenancy_namespace}/oracleidentitycloudservice/{username}."
+    description: "The user name to access the Oracle Cloud Infrastructure Registry (OCIR) for deploying autoscaling OCI functions. If the user is in an identity domain, use the format {tenancy_namespace}/{identity domain name}/{username}, otherwise use the format {username}.  If your tenancy is using Oracle Identity Cloud Service, use the format {tenancy_namespace}/oracleidentitycloudservice/{username}."
     required: true
 
   ocir_auth_token_compartment_id:

--- a/terraform/schema_15110.yaml
+++ b/terraform/schema_15110.yaml
@@ -2138,7 +2138,7 @@ variables:
             - ${use_autoscaling}
     type: string
     title: "Registry User Name"
-    description: "The user name to access the Oracle Cloud Infrastructure Registry (OCIR) for deploying autoscaling OCI functions. If the user is in an identity domain, use the format {tenancy_namespace}/{identity domain name}/{username}, otherwise use the format {username}.  If your tenancy is using Oracle Identity Cloud Service, use the format {tenancy_namespace}/oracleidentitycloudservice/{username}."
+    description: "The user name to access the Oracle Cloud Infrastructure Registry (OCIR) for deploying autoscaling OCI functions, which has the format {identity domain name}/{username}. If the user is in the default identity domain, do not include the identity domain name and use the format {username}. Or for example if your tenancy is using Oracle Identity Cloud Service, use the format {tenancy_namespace}/oracleidentitycloudservice/{username}."
     required: true
 
   ocir_auth_token_compartment_id:

--- a/terraform/schema_15110.yaml
+++ b/terraform/schema_15110.yaml
@@ -2138,7 +2138,7 @@ variables:
             - ${use_autoscaling}
     type: string
     title: "Registry User Name"
-    description: "The user name to access the Oracle Cloud Infrastructure Registry (OCIR) for deploying autoscaling OCI functions, which has the format {identity domain name}/{username}. If the user is in the default identity domain, do not include the identity domain name and use the format {username}. Or for example if your tenancy is using Oracle Identity Cloud Service, use the format {tenancy_namespace}/oracleidentitycloudservice/{username}."
+    description: "The user name to access the Oracle Cloud Infrastructure Registry (OCIR) for deploying autoscaling OCI functions has the format {tenancy namespace}{identity domain name}/{user name}. If the user is in the Default identity domain, do not include {identity domain name}. If you do not know the tenancy namespace do not add {tenancy_namespace} and let the stack set this for you. For example, if you don't know your tenancy namespace and your tenancy is federated with Oracle Identity Cloud Service with an identity domain of oracleidentitycloudservice you would set oracleidentitycloudservice/{username}."
     required: true
 
   ocir_auth_token_compartment_id:

--- a/terraform/schema_15110.yaml
+++ b/terraform/schema_15110.yaml
@@ -2138,7 +2138,7 @@ variables:
             - ${use_autoscaling}
     type: string
     title: "Registry User Name"
-    description: "The user name to access the Oracle Cloud Infrastructure Registry (OCIR) for deploying autoscaling OCI functions has the format {tenancy namespace}{identity domain name}/{user name}. If the user is in the Default identity domain, do not include {identity domain name}. If you do not know the tenancy namespace do not add {tenancy_namespace} and let the stack set this for you. For example, if you don't know your tenancy namespace and your tenancy is federated with Oracle Identity Cloud Service with an identity domain of oracleidentitycloudservice you would set oracleidentitycloudservice/{username}."
+    description: "The user name to access the Oracle Cloud Infrastructure Registry (OCIR) for deploying autoscaling OCI functions has the format {tenancy namespace}/{identity domain name}/{user name}. If the user is in the Default identity domain, do not include {identity domain name}. If you do not know the tenancy namespace do not add {tenancy_namespace} and let the stack set this for you. For example, if you don't know your tenancy namespace and your tenancy is federated with Oracle Identity Cloud Service with an identity domain of oracleidentitycloudservice you would set oracleidentitycloudservice/{username}."
     required: true
 
   ocir_auth_token_compartment_id:


### PR DESCRIPTION
When the OCIR user is specified for a BOAT user (e.g. bmc_operator_access/myuser) for autoscaling the tenancy namespace for the tenancy on which a WLS for OCI stack is applied is added to the user name (e.g. paasprodjcs/bmc_operator_access/myuser). Since the bmc_operator_access is the tenancy namespace the addition of the additional tenancy namespace causes OCIR requests to fail.

With agreement from the proposal suggested by Adrian, we are going with the following change - 
If the ocir_username entered contains '/', then we assume that the customer has entered the complete info including the tenancy_namespace, identity domain and the username.
If the ocir_username doesn't have a '/', then we append the namespace to it.

Testing - 
a.) Created a stack with the tenancy namespace added. - Podman login was successful and the namespace was not appended again.
b.) Created a stack without the namespace in the ocir_user variable - Stack provisioning did append the namespace and in our case it was the tenancy namespace where the stack is created 