### PR TITLE
JCS-14667 - WLS/OCI logging: dynamic group picker lists dynamic group…

### DIFF
--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, 2025, Oracle and/or its affiliates.
+# Copyright (c) 2023, 2026, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 locals {
@@ -156,6 +156,8 @@ locals {
 
   use_apm_service           = (var.use_apm_service || var.use_autoscaling)
   apm_domain_compartment_id = local.use_apm_service ? lookup(data.oci_apm_apm_domain.apm_domain[0], "compartment_id") : ""
+
+  dynamic_group_id = var.use_dg_from_default_identity_domain ? var.dynamic_group_id : var.dynamic_group_id_text
 
   ocir_namespace = data.oci_objectstorage_namespace.object_namespace.namespace
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, 2025, Oracle and/or its affiliates.
+# Copyright (c) 2023, 2026, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 ### Removing network validation script from provisioning flow temporarily.
@@ -444,7 +444,7 @@ module "validators" {
 
   create_policies  = var.create_policies
   use_oci_logging  = var.use_oci_logging
-  dynamic_group_id = var.dynamic_group_id
+  dynamic_group_id = local.dynamic_group_id
 
   use_apm_service           = local.use_apm_service
   apm_domain_id             = var.apm_domain_id
@@ -776,7 +776,7 @@ module "observability-logging" {
   oci_managed_instances_principal_group = element(concat(module.policies[*].oci_managed_instances_principal_group, [""]), 0)
   service_prefix_name                   = local.service_name_prefix
   create_policies                       = var.create_policies
-  dynamic_group_id                      = var.dynamic_group_id
+  dynamic_group_id                      = local.dynamic_group_id
   log_group_id                          = module.observability-common[0].log_group_id
   use_oci_logging                       = var.use_oci_logging
   tags = {

--- a/terraform/observability_variables.tf
+++ b/terraform/observability_variables.tf
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, Oracle and/or its affiliates.
+# Copyright (c) 2023, 2026, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 variable "use_oci_logging" {
@@ -8,6 +8,20 @@ variable "use_oci_logging" {
 }
 
 variable "dynamic_group_id" {
+  type        = string
+  description = "The dynamic group that contains the WebLogic instances from which logs will be exported to OCI Logging Service"
+  default     = ""
+}
+
+# Variable used in UI only
+variable "use_dg_from_default_identity_domain" {
+  type        = bool
+  description = "Indicates if the user wants to select the dynamic group in the ORM UI, which currently supports selecting dynamic groups from the default identity domain only"
+  default     = true
+}
+
+# Variable used in UI only
+variable "dynamic_group_id_text" {
   type        = string
   description = "The dynamic group that contains the WebLogic instances from which logs will be exported to OCI Logging Service"
   default     = ""

--- a/terraform/schema.yaml
+++ b/terraform/schema.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, 2025, Oracle and/or its affiliates.
+# Copyright (c) 2023, 2026, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 title: Oracle WebLogic Server for Oracle Cloud Infrastructure
@@ -166,7 +166,9 @@ groupings:
 
   - title: "OCI Logging"
     variables:
+      - ${use_dg_from_default_identity_domain}
       - ${dynamic_group_id}
+      - ${dynamic_group_id_text}
 
   - title: "Application Performance Monitoring"
     visible:
@@ -2401,14 +2403,41 @@ variables:
     visible:
       and:
         - ${use_oci_logging}
+        - ${use_dg_from_default_identity_domain}
         - not:
             - ${create_policies}
     type: oci:identity:dynamicgroups:id
-    title: "Dynamic Group OCID for WebLogic Server Instances"
+    title: "Dynamic Group in Default Identity Domain for WebLogic Server Instances"
     dependsOn:
       compartmentId: ${tenancy_ocid}
-    description: "The OCID of the dynamic group that contains the WebLogic instances from which logs will be exported to OCI Logging Service."
+    description: "The dynamic group that contains the WebLogic instances from which logs will be exported to OCI Logging Service."
     required: true
+
+  use_dg_from_default_identity_domain:
+    visible:
+      and:
+        - ${use_oci_logging}
+        - not:
+            - ${create_policies}
+    type: boolean
+    required: true
+    default: true
+    title: "Select Dynamic Group from Default Identity Domain"
+    description: "Select a dynamic group from the default identity domain."
+
+  dynamic_group_id_text:
+    visible:
+      and:
+        - ${use_oci_logging}
+        - not:
+            - ${use_dg_from_default_identity_domain}
+        - not:
+            - ${create_policies}
+    type: string
+    required: true
+    title: "Dynamic Group OCID for WebLogic Server Instances"
+    description: "The OCID of the dynamic group that contains the WebLogic instances from which logs will be exported to OCI Logging Service."
+    pattern: ^ocid1.dynamicgroup.*$
 
   image_mode:
     visible:

--- a/terraform/schema.yaml
+++ b/terraform/schema.yaml
@@ -2407,7 +2407,7 @@ variables:
         - not:
             - ${create_policies}
     type: oci:identity:dynamicgroups:id
-    title: "Dynamic Group in Default Identity Domain for WebLogic Server Instances"
+    title: "Dynamic Group in the Default Identity Domain for WebLogic Server Instances"
     dependsOn:
       compartmentId: ${tenancy_ocid}
     description: "The dynamic group that contains the WebLogic instances from which logs will be exported to OCI Logging Service."

--- a/terraform/schema_14110.yaml
+++ b/terraform/schema_14110.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, 2025, Oracle and/or its affiliates.
+# Copyright (c) 2023, 2026, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 title: Oracle WebLogic Server for Oracle Cloud Infrastructure
@@ -139,7 +139,9 @@ groupings:
 
   - title: "OCI Logging"
     variables:
+      - ${use_dg_from_default_identity_domain}
       - ${dynamic_group_id}
+      - ${dynamic_group_id_text}
 
   - title: "Application Performance Monitoring"
     visible:
@@ -1938,14 +1940,41 @@ variables:
     visible:
       and:
         - ${use_oci_logging}
+        - ${use_dg_from_default_identity_domain}
         - not:
             - ${create_policies}
     type: oci:identity:dynamicgroups:id
-    title: "Dynamic Group OCID for WebLogic Server Instances"
+    title: "Dynamic Group in Default Identity Domain for WebLogic Server Instances"
     dependsOn:
       compartmentId: ${tenancy_ocid}
-    description: "The OCID of the dynamic group that contains the WebLogic instances from which logs will be exported to OCI Logging Service."
+    description: "The dynamic group that contains the WebLogic instances from which logs will be exported to OCI Logging Service."
     required: true
+
+  use_dg_from_default_identity_domain:
+    visible:
+      and:
+        - ${use_oci_logging}
+        - not:
+            - ${create_policies}
+    type: boolean
+    required: true
+    default: true
+    title: "Select Dynamic Group from Default Identity Domain"
+    description: "Select a dynamic group from the default identity domain."
+
+  dynamic_group_id_text:
+    visible:
+      and:
+        - ${use_oci_logging}
+        - not:
+            - ${use_dg_from_default_identity_domain}
+        - not:
+            - ${create_policies}
+    type: string
+    required: true
+    title: "Dynamic Group OCID for WebLogic Server Instances"
+    description: "The OCID of the dynamic group that contains the WebLogic instances from which logs will be exported to OCI Logging Service."
+    pattern: ^ocid1.dynamicgroup.*$
 
   image_mode:
     visible:

--- a/terraform/schema_14110.yaml
+++ b/terraform/schema_14110.yaml
@@ -1944,7 +1944,7 @@ variables:
         - not:
             - ${create_policies}
     type: oci:identity:dynamicgroups:id
-    title: "Dynamic Group in Default Identity Domain for WebLogic Server Instances"
+    title: "Dynamic Group in the Default Identity Domain for WebLogic Server Instances"
     dependsOn:
       compartmentId: ${tenancy_ocid}
     description: "The dynamic group that contains the WebLogic instances from which logs will be exported to OCI Logging Service."

--- a/terraform/schema_14120.yaml
+++ b/terraform/schema_14120.yaml
@@ -2416,7 +2416,7 @@ variables:
         - not:
             - ${create_policies}
     type: oci:identity:dynamicgroups:id
-    title: "Dynamic Group in Default Identity Domain for WebLogic Server Instances"
+    title: "Dynamic Group in the Default Identity Domain for WebLogic Server Instances"
     dependsOn:
       compartmentId: ${tenancy_ocid}
     description: "The dynamic group that contains the WebLogic instances from which logs will be exported to OCI Logging Service."

--- a/terraform/schema_14120.yaml
+++ b/terraform/schema_14120.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, 2025, Oracle and/or its affiliates.
+# Copyright (c) 2023, 2026, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 title: Oracle WebLogic Server for Oracle Cloud Infrastructure
@@ -167,7 +167,9 @@ groupings:
 
   - title: "OCI Logging"
     variables:
+      - ${use_dg_from_default_identity_domain}
       - ${dynamic_group_id}
+      - ${dynamic_group_id_text}
 
   - title: "Application Performance Monitoring"
     visible:
@@ -2410,14 +2412,41 @@ variables:
     visible:
       and:
         - ${use_oci_logging}
+        - ${use_dg_from_default_identity_domain}
         - not:
             - ${create_policies}
     type: oci:identity:dynamicgroups:id
-    title: "Dynamic Group OCID for WebLogic Server Instances"
+    title: "Dynamic Group in Default Identity Domain for WebLogic Server Instances"
     dependsOn:
       compartmentId: ${tenancy_ocid}
-    description: "The OCID of the dynamic group that contains the WebLogic instances from which logs will be exported to OCI Logging Service."
+    description: "The dynamic group that contains the WebLogic instances from which logs will be exported to OCI Logging Service."
     required: true
+
+  use_dg_from_default_identity_domain:
+    visible:
+      and:
+        - ${use_oci_logging}
+        - not:
+            - ${create_policies}
+    type: boolean
+    required: true
+    default: true
+    title: "Select Dynamic Group from Default Identity Domain"
+    description: "Select a dynamic group from the default identity domain."
+
+  dynamic_group_id_text:
+    visible:
+      and:
+        - ${use_oci_logging}
+        - not:
+            - ${use_dg_from_default_identity_domain}
+        - not:
+            - ${create_policies}
+    type: string
+    required: true
+    title: "Dynamic Group OCID for WebLogic Server Instances"
+    description: "The OCID of the dynamic group that contains the WebLogic instances from which logs will be exported to OCI Logging Service."
+    pattern: ^ocid1.dynamicgroup.*$
 
   image_mode:
     visible:

--- a/terraform/schema_15110.yaml
+++ b/terraform/schema_15110.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, 2025, Oracle and/or its affiliates.
+# Copyright (c) 2023, 2026, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 title: Oracle WebLogic Server for Oracle Cloud Infrastructure
@@ -139,7 +139,9 @@ groupings:
 
   - title: "OCI Logging"
     variables:
+      - ${use_dg_from_default_identity_domain}
       - ${dynamic_group_id}
+      - ${dynamic_group_id_text}
 
   - title: "Application Performance Monitoring"
     visible:
@@ -1938,14 +1940,41 @@ variables:
     visible:
       and:
         - ${use_oci_logging}
+        - ${use_dg_from_default_identity_domain}
         - not:
             - ${create_policies}
     type: oci:identity:dynamicgroups:id
-    title: "Dynamic Group OCID for WebLogic Server Instances"
+    title: "Dynamic Group in Default Identity Domain for WebLogic Server Instances"
     dependsOn:
       compartmentId: ${tenancy_ocid}
-    description: "The OCID of the dynamic group that contains the WebLogic instances from which logs will be exported to OCI Logging Service."
+    description: "The dynamic group that contains the WebLogic instances from which logs will be exported to OCI Logging Service."
     required: true
+
+  use_dg_from_default_identity_domain:
+    visible:
+      and:
+        - ${use_oci_logging}
+        - not:
+            - ${create_policies}
+    type: boolean
+    required: true
+    default: true
+    title: "Select Dynamic Group from Default Identity Domain"
+    description: "Select a dynamic group from the default identity domain."
+
+  dynamic_group_id_text:
+    visible:
+      and:
+        - ${use_oci_logging}
+        - not:
+            - ${use_dg_from_default_identity_domain}
+        - not:
+            - ${create_policies}
+    type: string
+    required: true
+    title: "Dynamic Group OCID for WebLogic Server Instances"
+    description: "The OCID of the dynamic group that contains the WebLogic instances from which logs will be exported to OCI Logging Service."
+    pattern: ^ocid1.dynamicgroup.*$
 
   image_mode:
     visible:

--- a/terraform/schema_15110.yaml
+++ b/terraform/schema_15110.yaml
@@ -1944,7 +1944,7 @@ variables:
         - not:
             - ${create_policies}
     type: oci:identity:dynamicgroups:id
-    title: "Dynamic Group in Default Identity Domain for WebLogic Server Instances"
+    title: "Dynamic Group in the Default Identity Domain for WebLogic Server Instances"
     dependsOn:
       compartmentId: ${tenancy_ocid}
     description: "The dynamic group that contains the WebLogic instances from which logs will be exported to OCI Logging Service."


### PR DESCRIPTION
…s from the default domain only

- Allow users to specify the OCID of a dynamic group when configuring OCI logging, or select the dynamic group using the ORM dynamic group selector, which currently displays dynamic groups from the default identity domain only
- The option to select dynamic group from default identity domain is selected by default

These are some screen shots:
<img width="1026" height="272" alt="image" src="https://github.com/user-attachments/assets/67b2ec99-c45a-4dbe-95d3-61f20040f863" />

<img width="964" height="252" alt="image" src="https://github.com/user-attachments/assets/7a7d427f-222f-4ca1-b497-55c39a0e4c89" />

<img width="976" height="264" alt="image" src="https://github.com/user-attachments/assets/8a73f8db-bb70-44bb-9617-523d36aec11b" />

<img width="953" height="242" alt="image" src="https://github.com/user-attachments/assets/56ba167e-94d2-4b38-9dd5-b785a2820b75" />

<img width="1006" height="258" alt="image" src="https://github.com/user-attachments/assets/7c746f55-7f22-412d-935f-88e4eb04ac5c" />

Tests:
- For each supported release (12.2.1.4, 14.1.1.0, 14.1.2.0 and 15.1.1.0), create a bundle and use it to create an ORM stack
-  For each supported release:
    - create a stack without policies, and with OCI logging, and test different combinations of selecting the dynamic group and entering it manually, and verify the specified dynamic group is associated to the oci_logging_unified_agent_configuration resource. 
    - Test entering ocids with wrong OCI format
    - Create a stack with policies and OCI logging.  Verify the controls to select dynamic group are not displayed, and that the dynamic group created by the stack is associated to the oci_logging_unified_agent_configuration resource