### PR TITLE
JCS-15063 - Update App Gateway to version 25.3.32-2508110511

### DIFF
--- a/terraform/modules/compute/wls_compute/idcs_variables.tf
+++ b/terraform/modules/compute/wls_compute/idcs_variables.tf
@@ -74,13 +74,13 @@ variable "idcs_cloudgate_config_file" {
 variable "idcs_cloudgate_docker_image_tar" {
   type        = string
   description = "Path of the binary file with the container image to run IDCS cloudgate container in the WebLogic VM"
-  default     = "/u01/zips/jcs/app_gateway_docker/25.1.03/app-gateway-docker-image.tar.gz"
+  default     = "/u01/zips/jcs/app_gateway_docker/25.3.32/app-gateway-docker-image.tar.gz"
 }
 
 variable "idcs_cloudgate_docker_image_version" {
   type        = string
   description = "Version of the container image to run IDCS cloudgate container in the WebLogic VM"
-  default     = "25.1.03-2501230623"
+  default     = "25.3.32-2508110511"
 }
 
 variable "idcs_cloudgate_docker_image_name" {

--- a/terraform/modules/compute/wls_compute/idcs_variables.tf
+++ b/terraform/modules/compute/wls_compute/idcs_variables.tf
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, Oracle and/or its affiliates.
+# Copyright (c) 2023, 2026, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 variable "is_idcs_selected" {


### PR DESCRIPTION
JCS-15063 - Update App Gateway to version 25.3.32-2508110511

Testing - 

Testing-
1. New stack provisioning is successful with Appgateway version - 25.3.32-2508110511. The Appgateway docker image and container were running.
```
[opc@rajeshidcs1-wls-0 logs]$ sudo podman images
REPOSITORY                                       TAG                 IMAGE ID      CREATED       SIZE
local.local/idcs-appgateway-docker_linux_x86_64  25.3.32-2508110511  d782cf5d614d  5 months ago  667 MB
[opc@rajeshidcs1-wls-0 logs]$ sudo podman ps -a
CONTAINER ID  IMAGE                                                               COMMAND               CREATED         STATUS             PORTS       NAMES
674cae441183  local.local/idcs-appgateway-docker_linux_x86_64:25.3.32-2508110511  /bin/sh -c $CLOUD...  51 seconds ago  Up 52 seconds ago              appgateway
[opc@rajeshidcs1-wls-0 logs]$
```

2. Access the IDCS sample application by creating a ephemeral user in paasprodjcs tenancy.
<img width="1905" height="1041" alt="Screenshot 2026-01-08 at 6 11 14 PM" src="https://github.com/user-attachments/assets/0f63ed6b-b11e-4bda-8b1d-80181ee73409" />

3. Tested upgrade of existing appgateway 25.1.03 to new version 25.3.32-2508110511. Upgrade is successful.