### PR TITLE
Uptake new BYOL and UCM images

### DIFF
--- a/terraform/images/mp_image_ee_byol.tfvars
+++ b/terraform/images/mp_image_ee_byol.tfvars
@@ -1,13 +1,13 @@
 # Copyright (c) 2023, 2026, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-tf_script_version        = "26.1.1-260210065657"
+tf_script_version        = "26.1.1-260305123933"
 use_marketplace_image    = true
 listing_id               = "ocid1.appcataloglisting.oc1..aaaaaaaawd5ti5ldjzdppppi675onvo3mvjcwt64jjey7rib3beau2ngkl2q"
-listing_resource_version = "26.1.1-ol8.8-23.12.13-260210-1"
-instance_image_id        = "ocid1.image.oc1..aaaaaaaaehv6whetsenperh5w5enc4afuokpkeinljegjokcvrwnwrgsdzoa"
+listing_resource_version = "26.1.1-ol8.10-26.01.29-260305-1"
+instance_image_id        = "ocid1.image.oc1..aaaaaaaaz3hzhadlygo7sgabu5mxdtepltqfu6zvweqinuvjrk3hpsk4wrjq"
 
 ucm_listing_id               = "ocid1.appcataloglisting.oc1..aaaaaaaa653zc2e4fsem5hhwinmfgnv3xp4dmbq6c6gvf45okxf6xz3smhiq"
-ucm_listing_resource_version = "26.1.1-ol8.8-23.12.13-260210-1"
-ucm_instance_image_id        = "ocid1.image.oc1..aaaaaaaalyha6y6ynrlcmthtaczwsniqff3ccvoypowj4pg774xpo5abdk6a"
+ucm_listing_resource_version = "26.1.1-ol8.10-26.01.29-260305-1"
+ucm_instance_image_id        = "ocid1.image.oc1..aaaaaaaa5f6tlxuf6pe3sy7xpczfcxmxy4eg36emnrsvapmzy6bmljpz2goq"
 

--- a/terraform/images/mp_image_ee_ucm.tfvars
+++ b/terraform/images/mp_image_ee_ucm.tfvars
@@ -1,9 +1,9 @@
 # Copyright (c) 2023, 2026, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-tf_script_version        = "26.1.1-260210065657"
+tf_script_version        = "26.1.1-260305123933"
 use_marketplace_image    = true
 listing_id               = "ocid1.appcataloglisting.oc1..aaaaaaaa653zc2e4fsem5hhwinmfgnv3xp4dmbq6c6gvf45okxf6xz3smhiq"
-listing_resource_version = "26.1.1-ol8.8-23.12.13-260210-1"
-instance_image_id        = "ocid1.image.oc1..aaaaaaaalyha6y6ynrlcmthtaczwsniqff3ccvoypowj4pg774xpo5abdk6a"
+listing_resource_version = "26.1.1-ol8.10-26.01.29-260305-1"
+instance_image_id        = "ocid1.image.oc1..aaaaaaaa5f6tlxuf6pe3sy7xpczfcxmxy4eg36emnrsvapmzy6bmljpz2goq"
 

--- a/terraform/images/mp_image_se_byol.tfvars
+++ b/terraform/images/mp_image_se_byol.tfvars
@@ -1,8 +1,8 @@
 # Copyright (c) 2023, 2026, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-tf_script_version        = "26.1.1-260210065657"
+tf_script_version        = "26.1.1-260305123933"
 use_marketplace_image    = true
 listing_id               = "ocid1.appcataloglisting.oc1..aaaaaaaaalcwal6mfwjbezzqyj3waoxrvigml4n3lcn3hfday3ozetjqn25a"
-listing_resource_version = "26.1.1-ol8.8-23.12.13-260210-1"
-instance_image_id        = "ocid1.image.oc1..aaaaaaaa2g23i5jkejpi7rmti2brboqb2tskwzeobo4xnibami23e37frhja"
+listing_resource_version = "26.1.1-ol8.10-26.01.29-260305-1"
+instance_image_id        = "ocid1.image.oc1..aaaaaaaalrugepgz2vc67xfvdlqg2huad6hcjji2w4i2xtsvxpho73v77fkq"

--- a/terraform/images/mp_image_suite_byol.tfvars
+++ b/terraform/images/mp_image_suite_byol.tfvars
@@ -1,12 +1,12 @@
 # Copyright (c) 2023, 2026, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-tf_script_version        = "26.1.1-260210065657"
+tf_script_version        = "26.1.1-260305123933"
 use_marketplace_image    = true
 listing_id               = "ocid1.appcataloglisting.oc1..aaaaaaaajl5w3d76x5vdc4n7oqjpsxh4jtwivclvvp6gj4em3kufju6sftga"
-listing_resource_version = "26.1.1-ol8.8-23.12.13-260210-1"
-instance_image_id        = "ocid1.image.oc1..aaaaaaaamhl3vawpd7cf6tix5gptln7l2zmn6hljdb6hxu26m5y3mcd7rlla"
+listing_resource_version = "26.1.1-ol8.10-26.01.29-260305-1"
+instance_image_id        = "ocid1.image.oc1..aaaaaaaaypmo5z3ypbh66wqnxnq2debjbzqkbpp2rw5rxejf4b7otgu7amwq"
 
 ucm_listing_id               = "ocid1.appcataloglisting.oc1..aaaaaaaaq2vkow7zwkxg6ky4zxsnckdlfgtgmg7i4kkyev3y6zyo72mpkgza"
-ucm_listing_resource_version = "26.1.1-ol8.8-23.12.13-260210-1"
-ucm_instance_image_id        = "ocid1.image.oc1..aaaaaaaagt5ygm5yvlbz4qng2gf3whz3ucjhbuu2k3db5b4r75r2w3tezy7a"
+ucm_listing_resource_version = "26.1.1-ol8.10-26.01.29-260305-1"
+ucm_instance_image_id        = "ocid1.image.oc1..aaaaaaaaldttexupwxrojm2digdfpcpcmlasfn2h5zqibpwpdufdoju54u3a"

--- a/terraform/images/mp_image_suite_ucm.tfvars
+++ b/terraform/images/mp_image_suite_ucm.tfvars
@@ -1,8 +1,8 @@
 # Copyright (c) 2023, 2026, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-tf_script_version        = "26.1.1-260210065657"
+tf_script_version        = "26.1.1-260305123933"
 use_marketplace_image    = true
 listing_id               = "ocid1.appcataloglisting.oc1..aaaaaaaaq2vkow7zwkxg6ky4zxsnckdlfgtgmg7i4kkyev3y6zyo72mpkgza"
-listing_resource_version = "26.1.1-ol8.8-23.12.13-260210-1"
-instance_image_id        = "ocid1.image.oc1..aaaaaaaagt5ygm5yvlbz4qng2gf3whz3ucjhbuu2k3db5b4r75r2w3tezy7a"
+listing_resource_version = "26.1.1-ol8.10-26.01.29-260305-1"
+instance_image_id        = "ocid1.image.oc1..aaaaaaaaldttexupwxrojm2digdfpcpcmlasfn2h5zqibpwpdufdoju54u3a"

--- a/terraform/mp_variables.tf
+++ b/terraform/mp_variables.tf
@@ -11,7 +11,7 @@ variable "use_bastion_marketplace_image" {
 variable "bastion_image_id" {
   type        = string
   description = "The OCID of the marketplace bastion image"
-  default     = "ocid1.image.oc1..aaaaaaaablqmvpn633emdv7o2k42km6nxjt4i44aqwab3wxwquyz3ag6hvmq"
+  default     = "ocid1.image.oc1..aaaaaaaaze4v7mhg6xyewlvcul72fjoeryb3s4uttccocif6dii26ft5mblq"
 }
 
 variable "bastion_listing_id" {
@@ -23,7 +23,7 @@ variable "bastion_listing_id" {
 variable "bastion_listing_resource_version" {
   type        = string
   description = "The OCID of the marketplace bastion image listing resource version"
-  default     = "23.2.3-ol8.7-23.04.25-230702-1"
+  default     = "26.1.1-ol8.10-26.01.29-260305-1"
 }
 
 variable "use_marketplace_image" {

--- a/terraform/oci_images.tf
+++ b/terraform/oci_images.tf
@@ -19,7 +19,7 @@ variable "marketplace_source_images" {
       compatible_shapes     = []
     }
     baselinux_instance_image = {
-      ocid                  = "ocid1.image.oc1..aaaaaaaablqmvpn633emdv7o2k42km6nxjt4i44aqwab3wxwquyz3ag6hvmq"
+      ocid                  = "ocid1.image.oc1..aaaaaaaaze4v7mhg6xyewlvcul72fjoeryb3s4uttccocif6dii26ft5mblq"
       is_pricing_associated = false
       compatible_shapes     = []
     }


### PR DESCRIPTION
Uptake new BYOL image (without patching and patching utility) and UCM images (with updated OL 8.10 base image) and new MP bastion image (without patching and patching utility)