### PR TITLE
JCS-15312 - Update App Gateway to version 26.1.06-2602110936

### DIFF
--- a/terraform/modules/compute/wls_compute/idcs_variables.tf
+++ b/terraform/modules/compute/wls_compute/idcs_variables.tf
@@ -74,13 +74,13 @@ variable "idcs_cloudgate_config_file" {
 variable "idcs_cloudgate_docker_image_tar" {
   type        = string
   description = "Path of the binary file with the container image to run IDCS cloudgate container in the WebLogic VM"
-  default     = "/u01/zips/jcs/app_gateway_docker/25.3.32/app-gateway-docker-image.tar.gz"
+  default     = "/u01/zips/jcs/app_gateway_docker/26.1.06/app-gateway-docker-image.tar.gz"
 }
 
 variable "idcs_cloudgate_docker_image_version" {
   type        = string
   description = "Version of the container image to run IDCS cloudgate container in the WebLogic VM"
-  default     = "25.3.32-2508110511"
+  default     = "26.1.06-2602110936"
 }
 
 variable "idcs_cloudgate_docker_image_name" {


### PR DESCRIPTION
JCS-15312 - Update App Gateway to version 26.1.06-2602110936

Testing-

- New stack provisioning is successful with Appgateway version - 25.3.32-2508110511. The Appgateway docker image and container were running.

```
[opc@idcs26103-wls-0 ~]$ sudo podman images
REPOSITORY                                       TAG                 IMAGE ID      CREATED      SIZE
local.local/idcs-appgateway-docker_linux_x86_64  26.1.06-2602110936  0c54ca13a5ec  8 weeks ago  664 MB
[opc@idcs26103-wls-0 ~]$ sudo podman ps -a
CONTAINER ID  IMAGE                                                               COMMAND               CREATED            STATUS                PORTS       NAMES
3bfba2bfb137  local.local/idcs-appgateway-docker_linux_x86_64:26.1.06-2602110936  /bin/sh -c $CLOUD...  About an hour ago  Up About an hour ago              appgateway
[opc@idcs26103-wls-0 ~]$

```

- Access the IDCS sample application by creating a ephemeral user in paasprodjcs tenancy.

<img width="1462" height="832" alt="Screenshot 2026-04-10 at 10 56 11 PM" src="https://github.com/user-attachments/assets/fa68545b-0f80-44f7-88c2-aab89b71475d" />

- Tested upgrade of existing appgateway 25.3.32 to new version 26.1.06-2602110936. Upgrade is successful.
