### PR TITLE
JCS-15333 For new vcn scenario, Provisioning status is shown as asynchronous, even though bastion is present

### DIFF
--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -104,7 +104,7 @@ locals {
     local.lb_ip,
   ) : ""
 
-  async_prov_mode = !local.assign_weblogic_public_ip && !var.is_rms_private_endpoint_required && !var.is_bastion_instance_required ? "Asynchronous provisioning is enabled. Connect to each compute instance and confirm that the file /u01/data/domains/${format("%s_domain", local.service_name_prefix)}/provCompletedMarker exists. Details are found in the file /u01/logs/provisioning.log." : ""
+  async_prov_mode = !local.assign_weblogic_public_ip && !var.is_rms_private_endpoint_required && !local.is_bastion_instance_required ? "Asynchronous provisioning is enabled. Connect to each compute instance and confirm that the file /u01/data/domains/${format("%s_domain", local.service_name_prefix)}/provCompletedMarker exists. Details are found in the file /u01/logs/provisioning.log." : ""
 
   jdk_labels  = { jdk7 = "JDK 7", jdk8 = "JDK 8", jdk11 = "JDK 11", jdk17 = "JDK 17", jdk21 = "JDK 21" }
   jdk_version = lookup(
@@ -118,8 +118,8 @@ locals {
 
   user_defined_tag_values = values(var.service_tags.definedTags)
 
-  ssh_proxyjump_access = local.assign_weblogic_public_ip || !var.is_bastion_instance_required ? "" : format("ssh -i <privateKey> -o ProxyCommand=\"ssh -i <privateKey> -W %s -p 22 opc@%s\" -p 22 %s", "%h:%p", local.bastion_public_ip, "opc@<wls_vm_private_ip>")
-  ssh_dp_fwd           = local.assign_weblogic_public_ip || !var.is_bastion_instance_required ? "" : format("ssh -i <privatekey> -C -D <local-port> opc@%s", local.bastion_public_ip)
+  ssh_proxyjump_access = local.assign_weblogic_public_ip || !local.is_bastion_instance_required ? "" : format("ssh -i <privateKey> -o ProxyCommand=\"ssh -i <privateKey> -W %s -p 22 opc@%s\" -p 22 %s", "%h:%p", local.bastion_public_ip, "opc@<wls_vm_private_ip>")
+  ssh_dp_fwd           = local.assign_weblogic_public_ip || !local.is_bastion_instance_required ? "" : format("ssh -i <privatekey> -C -D <local-port> opc@%s", local.bastion_public_ip)
 
   use_existing_subnets = var.wls_subnet_id == "" && var.lb_subnet_1_id == "" && var.lb_subnet_2_id == "" ? false : true
 


### PR DESCRIPTION
JCS-15333 For new vcn scenario, Provisioning status is shown as asynchronous, even though bastion is present

Changes - 
- Observed in `terraform/locals.tf`, the `async_prov_mode` local variable uses `var.is_bastion_instance_required` instead of `local.is_bastion_instance_required`. The variable version is the user input, while the local version contains the computed logic that determines if bastion is actually required based on VCN configuration.
- Changed `var.is_bastion_instance_required` to `local.is_bastion_instance_required` in the async_prov_mode condition.

Testing - 
- Tested a provisioning with new VCN. The provisioning is successful and the asynchronous provisioning message is not present.

```
Apply complete! Resources: 44 added, 0 changed, 0 destroyed.

Outputs:
autoscaling_function_application_id = ""
autoscaling_scalein_monitoring_alarm_id = ""
autoscaling_scaleout_monitoring_alarm_id = ""
bastion_instance_id = "ocid1.instance.oc1.phx.anyhqljtncovviycfl2b67xfyfbkybelfecaqewyynkpwwhwc62utr56477q"
bastion_instance_public_ip = "129.146.133.123"
fss_system_id = ""
fusion_middleware_control_console = ""
is_vcn_peered = false
jdk_version = "JDK 17"
listing_version = "26.1.1-260305123933"
load_balancer_id = ""
load_balancer_ip = ""
mount_target_id = ""
provisioning_status = ""
resource_identifier_value = tolist([
  "nayawls-c6a474d1",
])
rms_private_endpoint_id = ""
sample_application = "https://10.0.2.30:7004/sample-app"
sample_application_protected_by_idcs = ""
ssh_command = "ssh -i <privateKey> -o ProxyCommand=\"ssh -i <privateKey> -W %h:%p -p 22 opc@129.146.133.123\" -p 22 opc@<wls_vm_private_ip>"
ssh_command_with_dynamic_port_forwarding = "ssh -i <privatekey> -C -D <local-port> opc@129.146.133.123"
virtual_cloud_network_cidr = "10.0.0.0/16"
virtual_cloud_network_id = "ocid1.vcn.oc1.phx.amaaaaaancovviyasmhqhsohknwwvm32vdpalepawiniftehpy7khobuibza"
webLogic_server_domain_configuration = "Production Mode"
weblogic_agent_configuration_id = ""
weblogic_instances = "[\"{ Instance Id:ocid1.instance.oc1.phx.anyhqljtncovviycuf2ux4fgqjyjx67ap5hr4e4lvgyisg7o6vmtk3od322a, Instance name:nayawls-wls-0, Availability Domain:PEKi:PHX-AD-1, Instance Shape:VM.Standard.E4.Flex, Private IP:10.0.2.30, Public IP: }\"]"
weblogic_log_group_id = ""
weblogic_log_id = ""
weblogic_server_administration_console = "https://10.0.2.30:7002/console"
weblogic_version = "14.1.2.0 Suite Edition (Non JRF)"

```