### PR TITLE
Making the fix for secure mode and egress rule for WLS subnet

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -24,6 +24,7 @@ module "network-validation" {
   lb_source_cidr                 = var.add_load_balancer ? (var.is_lb_private ? "" : "0.0.0.0/0") : ""
   secure_mode                    = var.configure_secure_mode
   idcs_cloudgate_port            = var.idcs_cloudgate_port
+  administration_port            = var.administration_port
 }
 
 module "system-tags" {

--- a/terraform/modules/network-validator/locals.tf
+++ b/terraform/modules/network-validator/locals.tf
@@ -14,7 +14,7 @@ locals {
   validation_script_oci_db_dbsystem_id_param             = var.oci_db_dbsystem_id != "" ? format("--ocidbid %s", var.oci_db_dbsystem_id) : ""
   validation_script_oci_db_port_param                    = var.oci_db_port != 0 ? format("--ocidbport %s", var.oci_db_port) : ""
   validation_script_http_port_param                      = var.wls_extern_admin_port != "" ? format("--http_port %s", var.wls_extern_admin_port) : ""
-  validation_script_https_port_param                     = var.wls_extern_ssl_admin_port != "" ? format("--https_port %s", var.wls_extern_ssl_admin_port) : ""
+  validation_script_https_port_param                     = var.secure_mode ? var.administration_port : var.wls_extern_ssl_admin_port != "" ? format("--https_port %s", var.wls_extern_ssl_admin_port) : ""
   validation_script_existing_admin_server_nsg_id_param   = var.existing_admin_server_nsg_id != "" ? format("--adminsrvnsg %s", var.existing_admin_server_nsg_id) : ""
   validation_script_existing_managed_server_nsg_id_param = var.existing_managed_server_nsg_id != "" ? format("--managedsrvnsg %s", var.existing_managed_server_nsg_id) : ""
   validation_script_existing_lb_nsg_id_param             = var.existing_lb_nsg_id != "" ? format("--lbnsg %s", var.existing_lb_nsg_id) : ""

--- a/terraform/modules/network-validator/scripts/network_validation.sh
+++ b/terraform/modules/network-validator/scripts/network_validation.sh
@@ -1273,18 +1273,25 @@ then
       fi
     fi
   fi
-  # Check if Egress rule to DB port is present in WLS subnet security list or Managed Server NSG
-  db_subnet_cidr_block=$(oci network subnet get --subnet-id ${ocidb_subnet_ocid} | jq -r '.data["cidr-block"]')
-  if [[ -n ${MANAGED_SRV_NSG_OCID} ]]; then
-    res=$(check_egress_db_traffic_in_nsg_or_seclist ${MANAGED_SRV_NSG_OCID}  "nsg" ${db_subnet_cidr_block} ${DB_PORT})
-  else
-    res=$(validate_db_egress_rule ${WLS_SUBNET_OCID} ${db_subnet_cidr_block} ${DB_PORT})
-  fi
 
-  if [[ $res -ne 0 ]]; then
-    echo "ERROR: Egress rule - DB port ${DB_PORT} is not open for access by DB Subnet CIDR [${db_subnet_cidr_block}] in WLS Subnet [${WLS_SUBNET_OCID}] or in WLS NSG [${MANAGED_SRV_NSG_OCID}]."
-    validation_return_code=2
-  fi
+  #####################################################################################################################
+  # This block of code is currently commented out since we are setting a broader egress rule which is open for
+  # all protocols on all ports. Later when we allow the customers to narrow down the egress rule to specific
+  # ports and specific protocols we can uncomment the below code as this would check for the egress rule on WLS
+  # subnet side for DB port
+  ######################################################################################################################
+  # Check if Egress rule to DB port is present in WLS subnet security list or Managed Server NSG
+#  db_subnet_cidr_block=$(oci network subnet get --subnet-id ${ocidb_subnet_ocid} | jq -r '.data["cidr-block"]')
+#  if [[ -n ${MANAGED_SRV_NSG_OCID} ]]; then
+#    res=$(check_egress_db_traffic_in_nsg_or_seclist ${MANAGED_SRV_NSG_OCID}  "nsg" ${db_subnet_cidr_block} ${DB_PORT})
+#  else
+#    res=$(validate_db_egress_rule ${WLS_SUBNET_OCID} ${db_subnet_cidr_block} ${DB_PORT})
+#  fi
+#
+#  if [[ $res -ne 0 ]]; then
+#    echo "ERROR: Egress rule - DB port ${DB_PORT} is not open for access by DB Subnet CIDR [${db_subnet_cidr_block}] in WLS Subnet [${WLS_SUBNET_OCID}] or in WLS NSG [${MANAGED_SRV_NSG_OCID}]."
+#    validation_return_code=2
+#  fi
 fi
 
 ### Validation - Only when ATP DB OCID is provided ###

--- a/terraform/modules/network-validator/variables.tf
+++ b/terraform/modules/network-validator/variables.tf
@@ -100,3 +100,9 @@ variable "idcs_cloudgate_port" {
   type        = number
   description = "The listen port for the Identity Cloud Service App Gateway, which authenticates requests and redirects them to WebLogic Server"
 }
+
+variable "administration_port" {
+  type        = number
+  description = "The domain-wide administration port to configure a secure WebLogic domain"
+  default     = 9002
+}


### PR DESCRIPTION
During the testing, we identified 2 problems - 
a.) For the secure mode, we need to use the administration port as the https_port but in the script we were passing the wls_admin_ssl_port.
b.) For the WLS subnet, we had added a check for the egress rule to be open for DB port. Since we ask the customers to have the wide port open for all protocols, this would be a redundant check.

In this PR, we are making both the changes. For the egress rule, we are commenting the code since we could reuse it later when we narrow down the egress rules.