### PR TITLE
Network validation to pass with egress all protocols being set

### DIFF
--- a/terraform/modules/network-validator/scripts/network_validation.sh
+++ b/terraform/modules/network-validator/scripts/network_validation.sh
@@ -492,7 +492,16 @@ function check_egress_db_traffic_in_nsg_or_seclist() {
                 continue
             fi
 
-            if [[ $egress_protocol == "6"  && $egress_destination == "$db_cidr" && ( $db_port -ge $port_min && $db_port -le $port_max )  ]]
+            # If all protocols are allowed to all destinations, DB egress is already covered.
+            if [[ $egress_protocol == "all" && $egress_destination == "0.0.0.0/0" ]]
+            then
+              port_is_open=true
+              echo 0
+              return
+            fi
+
+            # Otherwise, verify that a specific TCP egress rule exists for the DB CIDR and DB port.
+            if [[ $egress_protocol == "6" && $egress_destination == "$db_cidr" && ( $db_port -ge $port_min && $db_port -le $port_max ) ]]
             then
               port_is_open=true
               echo 0


### PR DESCRIPTION
Even with egress allowing all protocols and ports access if you provision with JRF using ATP with private endpoint you get the error:
`exit status 2. Output: ERROR: Egress rule - DB port 1522 is not open for access by DB Subnet CIDR`

In this PR we are making sure if the Egress rule for all protocols is being set for the CIDR range 0.0.0.0/0, then the network validation script needs to pass without having to check if the DB port is open. But if the broader CIDR range is not open in the egress rule, then we verify that the DB port access is provided in the egress rule.

Testing - 
a.) Created a stack with the existing validation script and reproduced the issue with the network validation script failure.
b.) Edited the stack with the new bundle containing the fix and the network validation script succeeded.